### PR TITLE
refactor: enable ruff linter and modernize conformance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/__pycache__
+.pytest_cache
+.ruff_cache
+uv.lock
+.venv

--- a/ap2_test.py
+++ b/ap2_test.py
@@ -19,7 +19,9 @@ import integration_test_utils
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
 from ucp_sdk.models.schemas.shopping.ap2_mandate import Ap2CompleteRequest
 from ucp_sdk.models.schemas.shopping.ap2_mandate import CheckoutMandate
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 from ucp_sdk.models.schemas.shopping.types import card_payment_instrument
 from ucp_sdk.models.schemas.shopping.types import payment_instrument
 from ucp_sdk.models.schemas.shopping.types import token_credential_resp
@@ -47,18 +49,18 @@ class Ap2MandateTest(integration_test_utils.IntegrationTestBase):
     checkout_id = checkout.Checkout(**response_json).id
 
     credential = token_credential_resp.TokenCredentialResponse(
-        type="token", token="success_token"
+      type="token", token="success_token"
     )
     instr = payment_instrument.PaymentInstrument(
-        root=card_payment_instrument.CardPaymentInstrument(
-            id="instr_1",
-            brand="visa",
-            last_digits="4242",
-            handler_id="mock_payment_handler",
-            handler_name="mock_payment_handler",
-            type="card",
-            credential=credential,
-        )
+      root=card_payment_instrument.CardPaymentInstrument(
+        id="instr_1",
+        brand="visa",
+        last_digits="4242",
+        handler_id="mock_payment_handler",
+        handler_name="mock_payment_handler",
+        type="card",
+        credential=credential,
+      )
     )
     payment_data = instr.root.model_dump(mode="json", exclude_none=True)
 
@@ -68,22 +70,22 @@ class Ap2MandateTest(integration_test_utils.IntegrationTestBase):
     ap2_data = Ap2CompleteRequest(checkout_mandate=mandate)
 
     payment_payload = {
-        "payment_data": payment_data,
-        "risk_signals": {},
-        "ap2": ap2_data.model_dump(mode="json", exclude_none=True),
+      "payment_data": payment_data,
+      "risk_signals": {},
+      "ap2": ap2_data.model_dump(mode="json", exclude_none=True),
     }
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=payment_payload,
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=payment_payload,
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 200)
     self.assertEqual(
-        response.json().get("status"),
-        "completed",
-        msg="Checkout status not 'completed'",
+      response.json().get("status"),
+      "completed",
+      msg="Checkout status not 'completed'",
     )
 
 

--- a/binding_test.py
+++ b/binding_test.py
@@ -17,7 +17,9 @@
 from absl.testing import absltest
 import integration_test_utils
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 from ucp_sdk.models.schemas.shopping.types import binding
 from ucp_sdk.models.schemas.shopping.types import card_payment_instrument
 from ucp_sdk.models.schemas.shopping.types import payment_identity
@@ -47,43 +49,43 @@ class TokenBindingTest(integration_test_utils.IntegrationTestBase):
     checkout_id = checkout.Checkout(**response_json).id
 
     identity = payment_identity.PaymentIdentity(
-        access_token="user_access_token"
+      access_token="user_access_token"
     )
     token_binding = binding.Binding(checkout_id=checkout_id, identity=identity)
 
     # TokenCredentialResponse allows extra fields
     credential = token_credential_resp.TokenCredentialResponse(
-        type="stripe_token", token="success_token", binding=token_binding
+      type="stripe_token", token="success_token", binding=token_binding
     )
 
     instr = payment_instrument.PaymentInstrument(
-        root=card_payment_instrument.CardPaymentInstrument(
-            id="instr_1",
-            brand="visa",
-            last_digits="4242",
-            handler_id="mock_payment_handler",
-            handler_name="mock_payment_handler",
-            type="card",
-            credential=credential,
-        )
+      root=card_payment_instrument.CardPaymentInstrument(
+        id="instr_1",
+        brand="visa",
+        last_digits="4242",
+        handler_id="mock_payment_handler",
+        handler_name="mock_payment_handler",
+        type="card",
+        credential=credential,
+      )
     )
     payment_data = instr.root.model_dump(mode="json", exclude_none=True)
     payment_payload = {
-        "payment_data": payment_data,
-        "risk_signals": {},
+      "payment_data": payment_data,
+      "risk_signals": {},
     }
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=payment_payload,
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=payment_payload,
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 200)
     self.assertEqual(
-        response.json().get("status"),
-        "completed",
-        msg="Checkout status not 'completed'",
+      response.json().get("status"),
+      "completed",
+      msg="Checkout status not 'completed'",
     )
 
 

--- a/card_credential_test.py
+++ b/card_credential_test.py
@@ -17,7 +17,9 @@
 from absl.testing import absltest
 import integration_test_utils
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 from ucp_sdk.models.schemas.shopping.types import card_credential
 from ucp_sdk.models.schemas.shopping.types import card_payment_instrument
 
@@ -44,40 +46,40 @@ class CardCredentialTest(integration_test_utils.IntegrationTestBase):
     checkout_id = checkout.Checkout(**response_json).id
 
     credential = card_credential.CardCredential(
-        type="card",
-        card_number_type="fpan",
-        number="4242424242424242",
-        expiry_month=12,
-        expiry_year=2030,
-        cvc="123",
-        name="John Doe",
+      type="card",
+      card_number_type="fpan",
+      number="4242424242424242",
+      expiry_month=12,
+      expiry_year=2030,
+      cvc="123",
+      name="John Doe",
     )
     instr = card_payment_instrument.CardPaymentInstrument(
-        id="instr_card",
-        handler_id="mock_payment_handler",
-        handler_name="mock_payment_handler",
-        type="card",
-        brand="Visa",
-        last_digits="1111",
-        credential=credential,
+      id="instr_card",
+      handler_id="mock_payment_handler",
+      handler_name="mock_payment_handler",
+      type="card",
+      brand="Visa",
+      last_digits="1111",
+      credential=credential,
     )
     payment_data = instr.model_dump(mode="json", exclude_none=True)
     payment_payload = {
-        "payment_data": payment_data,
-        "risk_signals": {},
+      "payment_data": payment_data,
+      "risk_signals": {},
     }
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=payment_payload,
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=payment_payload,
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 200)
     self.assertEqual(
-        response.json().get("status"),
-        "completed",
-        msg="Checkout status not 'completed'",
+      response.json().get("status"),
+      "completed",
+      msg="Checkout status not 'completed'",
     )
 
 

--- a/checkout_lifecycle_test.py
+++ b/checkout_lifecycle_test.py
@@ -19,7 +19,9 @@ import integration_test_utils
 from ucp_sdk.models.schemas.shopping import checkout_update_req
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
 from ucp_sdk.models.schemas.shopping import payment_update_req
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 from ucp_sdk.models.schemas.shopping.types import item_update_req
 from ucp_sdk.models.schemas.shopping.types import line_item_update_req
 
@@ -60,16 +62,16 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
     checkout_id = checkout.Checkout(**response_json).id
 
     response = self.client.get(
-        f"/checkout-sessions/{checkout_id}",
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      headers=integration_test_utils.get_headers(),
     )
     self.assert_response_status(response, 200)
 
     retrieved_checkout = checkout.Checkout(**response.json())
     self.assertEqual(
-        retrieved_checkout.id,
-        checkout_id,
-        msg="Get checkout returned wrong ID",
+      retrieved_checkout.id,
+      checkout_id,
+      msg="Get checkout returned wrong ID",
     )
 
   def test_update_checkout(self):
@@ -86,37 +88,37 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
 
     # Construct Update Request
     item_update = item_update_req.ItemUpdateRequest(
-        id=checkout_obj.line_items[0].item.id,
-        title=checkout_obj.line_items[0].item.title,
+      id=checkout_obj.line_items[0].item.id,
+      title=checkout_obj.line_items[0].item.title,
     )
     line_item_update = line_item_update_req.LineItemUpdateRequest(
-        id=checkout_obj.line_items[0].id,
-        item=item_update,
-        quantity=2,
+      id=checkout_obj.line_items[0].id,
+      item=item_update,
+      quantity=2,
     )
 
     payment_update = payment_update_req.PaymentUpdateRequest(
-        selected_instrument_id=checkout_obj.payment.selected_instrument_id,
-        instruments=checkout_obj.payment.instruments,
-        handlers=[
-            h.model_dump(mode="json", exclude_none=True)
-            for h in checkout_obj.payment.handlers
-        ],
+      selected_instrument_id=checkout_obj.payment.selected_instrument_id,
+      instruments=checkout_obj.payment.instruments,
+      handlers=[
+        h.model_dump(mode="json", exclude_none=True)
+        for h in checkout_obj.payment.handlers
+      ],
     )
 
     update_payload = checkout_update_req.CheckoutUpdateRequest(
-        id=checkout_id,
-        currency=checkout_obj.currency,
-        line_items=[line_item_update],
-        payment=payment_update,
+      id=checkout_id,
+      currency=checkout_obj.currency,
+      line_items=[line_item_update],
+      payment=payment_update,
     )
 
     response = self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 200)
@@ -133,16 +135,16 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
     checkout_id = checkout.Checkout(**response_json).id
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/cancel",
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/cancel",
+      headers=integration_test_utils.get_headers(),
     )
     self.assert_response_status(response, 200)
 
     canceled_checkout = checkout.Checkout(**response.json())
     self.assertEqual(
-        canceled_checkout.status,
-        "canceled",
-        msg=f"Checkout status not 'canceled', got '{canceled_checkout.status}'",
+      canceled_checkout.status,
+      "canceled",
+      msg=f"Checkout status not 'canceled', got '{canceled_checkout.status}'",
     )
 
   def test_complete_checkout(self):
@@ -158,9 +160,9 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
     checkout_id = checkout_obj.id
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=integration_test_utils.get_valid_payment_payload(),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=integration_test_utils.get_valid_payment_payload(),
+      headers=integration_test_utils.get_headers(),
     )
 
     if response.status_code == 409 and "stock" in response.text.lower():
@@ -170,30 +172,29 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
 
     completed_checkout = checkout.Checkout(**response.json())
     self.assertEqual(
-        completed_checkout.status,
-        "completed",
-        msg=(
-            "Checkout status not 'completed', got"
-            f" '{completed_checkout.status}'"
-        ),
+      completed_checkout.status,
+      "completed",
+      msg=(
+        f"Checkout status not 'completed', got '{completed_checkout.status}'"
+      ),
     )
     self.assertIsNotNone(
-        completed_checkout.order, "order object missing in completion response"
+      completed_checkout.order, "order object missing in completion response"
     )
     self.assertTrue(
-        completed_checkout.order.id,
-        "order.id missing",
+      completed_checkout.order.id,
+      "order.id missing",
     )
     self.assertTrue(
-        completed_checkout.order.permalink_url,
-        "order.permalink_url missing",
+      completed_checkout.order.permalink_url,
+      "order.permalink_url missing",
     )
 
   def _cancel_checkout(self, checkout_id):
-    """Helper to cancel a checkout."""
+    """Cancel a checkout."""
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/cancel",
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/cancel",
+      headers=integration_test_utils.get_headers(),
     )
     self.assert_response_status(response, 200)
     return response
@@ -219,13 +220,13 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
     # if checkout.status in [COMPLETED, CANCELED]:
     # raise CheckoutNotModifiableError -> 409
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/cancel",
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/cancel",
+      headers=integration_test_utils.get_headers(),
     )
     self.assertNotEqual(
-        response.status_code,
-        200,
-        msg="Should not be able to cancel an already canceled checkout.",
+      response.status_code,
+      200,
+      msg="Should not be able to cancel an already canceled checkout.",
     )
 
   def test_cannot_update_canceled_checkout(self):
@@ -243,40 +244,40 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
 
     # Try Update
     item_update = item_update_req.ItemUpdateRequest(
-        id=checkout_obj.line_items[0].item.id,
-        title=checkout_obj.line_items[0].item.title,
+      id=checkout_obj.line_items[0].item.id,
+      title=checkout_obj.line_items[0].item.title,
     )
     line_item_update = line_item_update_req.LineItemUpdateRequest(
-        id=checkout_obj.line_items[0].id,
-        item=item_update,
-        quantity=2,
+      id=checkout_obj.line_items[0].id,
+      item=item_update,
+      quantity=2,
     )
     payment_update = payment_update_req.PaymentUpdateRequest(
-        selected_instrument_id=checkout_obj.payment.selected_instrument_id,
-        instruments=checkout_obj.payment.instruments,
-        handlers=[
-            h.model_dump(mode="json", exclude_none=True)
-            for h in checkout_obj.payment.handlers
-        ],
+      selected_instrument_id=checkout_obj.payment.selected_instrument_id,
+      instruments=checkout_obj.payment.instruments,
+      handlers=[
+        h.model_dump(mode="json", exclude_none=True)
+        for h in checkout_obj.payment.handlers
+      ],
     )
     update_payload = checkout_update_req.CheckoutUpdateRequest(
-        id=checkout_id,
-        currency=checkout_obj.currency,
-        line_items=[line_item_update],
-        payment=payment_update,
+      id=checkout_id,
+      currency=checkout_obj.currency,
+      line_items=[line_item_update],
+      payment=payment_update,
     )
 
     response = self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=integration_test_utils.get_headers(),
     )
     self.assertNotEqual(
-        response.status_code,
-        200,
-        msg="Should not be able to update a canceled checkout.",
+      response.status_code,
+      200,
+      msg="Should not be able to update a canceled checkout.",
     )
 
   def test_cannot_complete_canceled_checkout(self):
@@ -293,22 +294,22 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
 
     # Try Complete
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=integration_test_utils.get_valid_payment_payload(),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=integration_test_utils.get_valid_payment_payload(),
+      headers=integration_test_utils.get_headers(),
     )
     self.assertNotEqual(
-        response.status_code,
-        200,
-        msg="Should not be able to complete a canceled checkout.",
+      response.status_code,
+      200,
+      msg="Should not be able to complete a canceled checkout.",
     )
 
   def _complete_checkout(self, checkout_id):
-    """Helper to complete a checkout."""
+    """Complete a checkout."""
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=integration_test_utils.get_valid_payment_payload(),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=integration_test_utils.get_valid_payment_payload(),
+      headers=integration_test_utils.get_headers(),
     )
     self.assert_response_status(response, 200)
     return response
@@ -328,14 +329,14 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
 
     # Try Complete again (new idempotency key)
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=integration_test_utils.get_valid_payment_payload(),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=integration_test_utils.get_valid_payment_payload(),
+      headers=integration_test_utils.get_headers(),
     )
     self.assertNotEqual(
-        response.status_code,
-        200,
-        msg="Should not be able to complete an already completed checkout.",
+      response.status_code,
+      200,
+      msg="Should not be able to complete an already completed checkout.",
     )
 
   def test_cannot_update_completed_checkout(self):
@@ -353,40 +354,40 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
 
     # Try Update
     item_update = item_update_req.ItemUpdateRequest(
-        id=checkout_obj.line_items[0].item.id,
-        title=checkout_obj.line_items[0].item.title,
+      id=checkout_obj.line_items[0].item.id,
+      title=checkout_obj.line_items[0].item.title,
     )
     line_item_update = line_item_update_req.LineItemUpdateRequest(
-        id=checkout_obj.line_items[0].id,
-        item=item_update,
-        quantity=2,
+      id=checkout_obj.line_items[0].id,
+      item=item_update,
+      quantity=2,
     )
     payment_update = payment_update_req.PaymentUpdateRequest(
-        selected_instrument_id=checkout_obj.payment.selected_instrument_id,
-        instruments=checkout_obj.payment.instruments,
-        handlers=[
-            h.model_dump(mode="json", exclude_none=True)
-            for h in checkout_obj.payment.handlers
-        ],
+      selected_instrument_id=checkout_obj.payment.selected_instrument_id,
+      instruments=checkout_obj.payment.instruments,
+      handlers=[
+        h.model_dump(mode="json", exclude_none=True)
+        for h in checkout_obj.payment.handlers
+      ],
     )
     update_payload = checkout_update_req.CheckoutUpdateRequest(
-        id=checkout_id,
-        currency=checkout_obj.currency,
-        line_items=[line_item_update],
-        payment=payment_update,
+      id=checkout_id,
+      currency=checkout_obj.currency,
+      line_items=[line_item_update],
+      payment=payment_update,
     )
 
     response = self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=integration_test_utils.get_headers(),
     )
     self.assertNotEqual(
-        response.status_code,
-        200,
-        msg="Should not be able to update a completed checkout.",
+      response.status_code,
+      200,
+      msg="Should not be able to update a completed checkout.",
     )
 
   def test_cannot_cancel_completed_checkout(self):
@@ -403,13 +404,13 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
 
     # Try Cancel
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/cancel",
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/cancel",
+      headers=integration_test_utils.get_headers(),
     )
     self.assertNotEqual(
-        response.status_code,
-        200,
-        msg="Should not be able to cancel a completed checkout.",
+      response.status_code,
+      200,
+      msg="Should not be able to cancel a completed checkout.",
     )
 
 

--- a/fulfillment_test.py
+++ b/fulfillment_test.py
@@ -18,7 +18,9 @@ import uuid
 from absl.testing import absltest
 import integration_test_utils
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 from ucp_sdk.models.schemas.shopping.types import postal_address
 
 # Rebuild models to resolve forward references
@@ -50,12 +52,12 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     # Use helper to get a valid address from CSV
     addr_data = integration_test_utils.test_data.addresses[0]
     address = postal_address.PostalAddress(
-        full_name="John Doe",
-        street_address=addr_data["street_address"],
-        address_locality=addr_data["city"],
-        address_region=addr_data["state"],
-        postal_code=addr_data["postal_code"],
-        address_country=addr_data["country"],
+      full_name="John Doe",
+      street_address=addr_data["street_address"],
+      address_locality=addr_data["city"],
+      address_region=addr_data["state"],
+      postal_code=addr_data["postal_code"],
+      address_country=addr_data["country"],
     )
 
     # Construct fulfillment payload
@@ -63,15 +65,17 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     address_data["id"] = "dest_1"  # Mock ID matching the injected address
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [address_data],
-            "selected_destination_id": "dest_1",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [address_data],
+          "selected_destination_id": "dest_1",
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment=fulfillment_payload
+      checkout_obj, fulfillment=fulfillment_payload
     )
     checkout_with_options = checkout.Checkout(**response_json)
 
@@ -85,39 +89,39 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     options = group.options
 
     self.assertTrue(
-        options,
-        f"Fulfillment options not generated. Resp: {response_json}",
+      options,
+      f"Fulfillment options not generated. Resp: {response_json}",
     )
 
     # 2. Select Option
     option_id = options[0].id
     option_cost = next(
-        (t.amount for t in options[0].totals if t.type == "total"), 0
+      (t.amount for t in options[0].totals if t.type == "total"), 0
     )
 
     # Update payload to select the option
     # We must preserve the destination to keep options available
     fulfillment_payload["methods"][0]["groups"] = [
-        {"selected_option_id": option_id}
+      {"selected_option_id": option_id}
     ]
 
     response_json = self.update_checkout_session(
-        checkout_with_options, fulfillment=fulfillment_payload
+      checkout_with_options, fulfillment=fulfillment_payload
     )
     final_checkout = checkout.Checkout(**response_json)
 
     expected_total = 3500 + option_cost  # Base 3500 + shipping
     total_obj = next(
-        (t for t in final_checkout.totals if t.type == "total"), None
+      (t for t in final_checkout.totals if t.type == "total"), None
     )
     self.assertIsNotNone(total_obj, "Total object missing")
     self.assertEqual(
-        total_obj.amount,
-        expected_total,
-        msg=(
-            f"Total not updated correctly. Expected {expected_total}, got"
-            f" {total_obj.amount}"
-        ),
+      total_obj.amount,
+      expected_total,
+      msg=(
+        f"Total not updated correctly. Expected {expected_total}, got"
+        f" {total_obj.amount}"
+      ),
     )
 
   def test_dynamic_fulfillment(self) -> None:
@@ -136,70 +140,74 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     # addr_1 is US in CSV
     addr_data = integration_test_utils.test_data.addresses[0]
     us_address = {
-        "id": "dest_us",
-        "address_country": addr_data["country"],
-        "postal_code": addr_data["postal_code"],
+      "id": "dest_us",
+      "address_country": addr_data["country"],
+      "postal_code": addr_data["postal_code"],
     }
 
     fulfillment_us = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [us_address],
-            "selected_destination_id": "dest_us",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [us_address],
+          "selected_destination_id": "dest_us",
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment=fulfillment_us
+      checkout_obj, fulfillment=fulfillment_us
     )
     us_checkout = checkout.Checkout(**response_json)
 
     # Check for US options
     options = us_checkout.fulfillment.root.methods[0].groups[0].options
     self.assertTrue(
-        options and any(o.id == "exp-ship-us" for o in options),
-        f"Expected US express option, got {options}",
+      options and any(o.id == "exp-ship-us" for o in options),
+      f"Expected US express option, got {options}",
     )
 
     # 2. Update with CA Address
     ca_address = {
-        "id": "dest_ca",
-        "address_country": "CA",
-        "postal_code": "M5V 2H1",
+      "id": "dest_ca",
+      "address_country": "CA",
+      "postal_code": "M5V 2H1",
     }
 
     fulfillment_ca = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [ca_address],
-            "selected_destination_id": "dest_ca",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [ca_address],
+          "selected_destination_id": "dest_ca",
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        us_checkout, fulfillment=fulfillment_ca
+      us_checkout, fulfillment=fulfillment_ca
     )
     ca_checkout = checkout.Checkout(**response_json)
 
     # Check for International options
     options = ca_checkout.fulfillment.root.methods[0].groups[0].options
     self.assertTrue(
-        options and any(o.id == "exp-ship-intl" for o in options),
-        f"Expected Intl express option, got {options}",
+      options and any(o.id == "exp-ship-intl" for o in options),
+      f"Expected Intl express option, got {options}",
     )
 
   def test_unknown_customer_no_address(self) -> None:
     """Test that an unknown customer gets no automatic address injection."""
     # Create checkout with unknown buyer
     response_json = self.create_checkout_session(
-        buyer={"fullName": "Unknown Person", "email": "unknown@example.com"},
-        select_fulfillment=False,
+      buyer={"fullName": "Unknown Person", "email": "unknown@example.com"},
+      select_fulfillment=False,
     )
     checkout_obj = checkout.Checkout(**response_json)
 
     # Trigger fulfillment update (empty payload to trigger sync)
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
+      checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
     )
     updated_checkout = checkout.Checkout(**response_json)
 
@@ -211,13 +219,13 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     """Test that a known customer with no stored address gets no injection."""
     # Jane Doe (cust_3) has no address in CSV
     response_json = self.create_checkout_session(
-        buyer={"fullName": "Jane Doe", "email": "jane.doe@example.com"},
-        select_fulfillment=False,
+      buyer={"fullName": "Jane Doe", "email": "jane.doe@example.com"},
+      select_fulfillment=False,
     )
     checkout_obj = checkout.Checkout(**response_json)
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
+      checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
     )
     updated_checkout = checkout.Checkout(**response_json)
 
@@ -228,13 +236,13 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     """Test that a known customer with an address gets it injected."""
     # John Doe (cust_1) has an address
     response_json = self.create_checkout_session(
-        buyer={"fullName": "John Doe", "email": "john.doe@example.com"},
-        select_fulfillment=False,
+      buyer={"fullName": "John Doe", "email": "john.doe@example.com"},
+      select_fulfillment=False,
     )
     checkout_obj = checkout.Checkout(**response_json)
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
+      checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
     )
     updated_checkout = checkout.Checkout(**response_json)
 
@@ -248,14 +256,14 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     """Test selecting between multiple addresses for a known customer."""
     # John Doe has 2 addresses: addr_1 and addr_2
     response_json = self.create_checkout_session(
-        buyer={"fullName": "John Doe", "email": "john.doe@example.com"},
-        select_fulfillment=False,
+      buyer={"fullName": "John Doe", "email": "john.doe@example.com"},
+      select_fulfillment=False,
     )
     checkout_obj = checkout.Checkout(**response_json)
 
     # Trigger injection
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
+      checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
     )
     updated_checkout = checkout.Checkout(**response_json)
 
@@ -270,55 +278,57 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
 
     # Select addr_2
     fulfillment_payload = {
-        "methods": [{"type": "shipping", "selected_destination_id": "addr_2"}]
+      "methods": [{"type": "shipping", "selected_destination_id": "addr_2"}]
     }
     response_json = self.update_checkout_session(
-        updated_checkout, fulfillment=fulfillment_payload
+      updated_checkout, fulfillment=fulfillment_payload
     )
     final_checkout = checkout.Checkout(**response_json)
 
     # Verify selection in hierarchical model
     self.assertEqual(
-        final_checkout.fulfillment.root.methods[0].selected_destination_id,
-        "addr_2",
+      final_checkout.fulfillment.root.methods[0].selected_destination_id,
+      "addr_2",
     )
 
     # Verify selection details from the selected destination
     method = final_checkout.fulfillment.root.methods[0]
     selected_dest = next(
-        d for d in method.destinations if d.root.id == "addr_2"
+      d for d in method.destinations if d.root.id == "addr_2"
     )
     self.assertEqual(
-        selected_dest.root.street_address,
-        "456 Oak Ave",
+      selected_dest.root.street_address,
+      "456 Oak Ave",
     )
     self.assertEqual(selected_dest.root.postal_code, "10012")
 
   def test_known_customer_new_address(self) -> None:
     """Test that providing a new address works for a known customer."""
     response_json = self.create_checkout_session(
-        buyer={"fullName": "John Doe", "email": "john.doe@example.com"}
+      buyer={"fullName": "John Doe", "email": "john.doe@example.com"}
     )
     checkout_obj = checkout.Checkout(**response_json)
 
     # Provide a new explicit destination
     new_address = {
-        "id": "dest_new",
-        "address_country": "CA",
-        "postal_code": "M5V 2H1",
-        "street_address": "123 New St",
+      "id": "dest_new",
+      "address_country": "CA",
+      "postal_code": "M5V 2H1",
+      "street_address": "123 New St",
     }
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [new_address],
-            "selected_destination_id": "dest_new",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [new_address],
+          "selected_destination_id": "dest_new",
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment=fulfillment_payload
+      checkout_obj, fulfillment=fulfillment_payload
     )
     updated_checkout = checkout.Checkout(**response_json)
 
@@ -348,32 +358,33 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     Then the address should be saved, assigned an ID, and reused for subsequent
     checkouts by the same user.
     """
-
     email = f"new.user.{uuid.uuid4()}@example.com"
     response_json = self.create_checkout_session(
-        buyer={"fullName": "New User", "email": email},
-        select_fulfillment=False,
+      buyer={"fullName": "New User", "email": email},
+      select_fulfillment=False,
     )
     checkout_obj = checkout.Checkout(**response_json)
 
     # New address without ID
     new_address = {
-        "street_address": "789 Pine St",
-        "address_locality": "Villagetown",
-        "address_region": "NY",
-        "postal_code": "10001",
-        "address_country": "US",
+      "street_address": "789 Pine St",
+      "address_locality": "Villagetown",
+      "address_region": "NY",
+      "postal_code": "10001",
+      "address_country": "US",
     }
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [new_address],
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [new_address],
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment=fulfillment_payload
+      checkout_obj, fulfillment=fulfillment_payload
     )
     updated_checkout = checkout.Checkout(**response_json)
 
@@ -388,12 +399,12 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     # Verify persistence by creating another checkout for same user
     # and checking if address is injected
     response_json_2 = self.create_checkout_session(
-        buyer={"fullName": "New User", "email": email},
-        select_fulfillment=False,
+      buyer={"fullName": "New User", "email": email},
+      select_fulfillment=False,
     )
     checkout_obj_2 = checkout.Checkout(**response_json_2)
     response_json_2 = self.update_checkout_session(
-        checkout_obj_2, fulfillment={"methods": [{"type": "shipping"}]}
+      checkout_obj_2, fulfillment={"methods": [{"type": "shipping"}]}
     )
     updated_checkout_2 = checkout.Checkout(**response_json_2)
     method_2 = updated_checkout_2.fulfillment.root.methods[0]
@@ -412,29 +423,31 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     """
     # John Doe has addr_1 (123 Main St, Springfield, IL, 62704, US)
     response_json = self.create_checkout_session(
-        buyer={"fullName": "John Doe", "email": "john.doe@example.com"},
-        select_fulfillment=False,
+      buyer={"fullName": "John Doe", "email": "john.doe@example.com"},
+      select_fulfillment=False,
     )
     checkout_obj = checkout.Checkout(**response_json)
 
     # Send address matching addr_1 but without ID
     matching_address = {
-        "street_address": "123 Main St",
-        "address_locality": "Springfield",
-        "address_region": "IL",
-        "postal_code": "62704",
-        "address_country": "US",
+      "street_address": "123 Main St",
+      "address_locality": "Springfield",
+      "address_region": "IL",
+      "postal_code": "62704",
+      "address_country": "US",
     }
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [matching_address],
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [matching_address],
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment=fulfillment_payload
+      checkout_obj, fulfillment=fulfillment_payload
     )
     updated_checkout = checkout.Checkout(**response_json)
 
@@ -454,33 +467,35 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     # addr_1 is US in CSV
     addr_data = integration_test_utils.test_data.addresses[0]
     address = {
-        "id": "dest_us",
-        "address_country": addr_data["country"],
-        "postal_code": addr_data["postal_code"],
+      "id": "dest_us",
+      "address_country": addr_data["country"],
+      "postal_code": addr_data["postal_code"],
     }
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [address],
-            "selected_destination_id": "dest_us",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [address],
+          "selected_destination_id": "dest_us",
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment=fulfillment_payload
+      checkout_obj, fulfillment=fulfillment_payload
     )
     updated_checkout = checkout.Checkout(**response_json)
 
     options = updated_checkout.fulfillment.root.methods[0].groups[0].options
     free_shipping_option = next(
-        (o for o in options if o.id == "std-ship"), None
+      (o for o in options if o.id == "std-ship"), None
     )
 
     self.assertIsNotNone(free_shipping_option)
     opt_total = next(
-        (t.amount for t in free_shipping_option.totals if t.type == "total"),
-        None,
+      (t.amount for t in free_shipping_option.totals if t.type == "total"),
+      None,
     )
     self.assertEqual(opt_total, 0)
     self.assertIn("Free", free_shipping_option.title)
@@ -494,33 +509,35 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     # addr_1 is US in CSV
     addr_data = integration_test_utils.test_data.addresses[0]
     address = {
-        "id": "dest_us",
-        "address_country": addr_data["country"],
-        "postal_code": addr_data["postal_code"],
+      "id": "dest_us",
+      "address_country": addr_data["country"],
+      "postal_code": addr_data["postal_code"],
     }
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [address],
-            "selected_destination_id": "dest_us",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [address],
+          "selected_destination_id": "dest_us",
+        }
+      ]
     }
 
     response_json = self.update_checkout_session(
-        checkout_obj, fulfillment=fulfillment_payload
+      checkout_obj, fulfillment=fulfillment_payload
     )
     updated_checkout = checkout.Checkout(**response_json)
 
     options = updated_checkout.fulfillment.root.methods[0].groups[0].options
     free_shipping_option = next(
-        (o for o in options if o.id == "std-ship"), None
+      (o for o in options if o.id == "std-ship"), None
     )
 
     self.assertIsNotNone(free_shipping_option)
     opt_total = next(
-        (t.amount for t in free_shipping_option.totals if t.type == "total"),
-        None,
+      (t.amount for t in free_shipping_option.totals if t.type == "total"),
+      None,
     )
     self.assertEqual(opt_total, 0)
     self.assertIn("Free", free_shipping_option.title)

--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -17,10 +17,10 @@
 import csv
 import json
 import logging
-import os
+from pathlib import Path
 import threading
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any
 import uuid
 
 from absl import flags
@@ -33,9 +33,13 @@ from ucp_sdk.models.schemas.shopping import checkout_create_req
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as f_models
 from ucp_sdk.models.schemas.shopping import payment_create_req
 from ucp_sdk.models.schemas.shopping import payment_update_req
-from ucp_sdk.models.schemas.shopping.discount_update_req import Checkout as DiscountUpdate
+from ucp_sdk.models.schemas.shopping.discount_update_req import (
+  Checkout as DiscountUpdate,
+)
 from ucp_sdk.models.schemas.shopping.fulfillment_create_req import Fulfillment
-from ucp_sdk.models.schemas.shopping.fulfillment_update_req import Checkout as FulfillmentUpdate
+from ucp_sdk.models.schemas.shopping.fulfillment_update_req import (
+  Checkout as FulfillmentUpdate,
+)
 from ucp_sdk.models.schemas.shopping.types import card_payment_instrument
 from ucp_sdk.models.schemas.shopping.types import fulfillment_destination_req
 from ucp_sdk.models.schemas.shopping.types import fulfillment_group_create_req
@@ -58,26 +62,26 @@ FLAGS = flags.FLAGS
 try:
   flags.DEFINE_string("server_url", None, "Base URL of the server")
   flags.DEFINE_string(
-      "simulation_secret",
-      str(uuid.uuid4()),
-      "Secret for simulation endpoints",
+    "simulation_secret",
+    str(uuid.uuid4()),
+    "Secret for simulation endpoints",
   )
   flags.DEFINE_integer(
-      "mock_webhook_port", 8284, "Port for the mock webhook server"
+    "mock_webhook_port", 8284, "Port for the mock webhook server"
   )
   flags.DEFINE_integer(
-      "mock_agent_port", 8285, "Port for the mock agent profile server"
+    "mock_agent_port", 8285, "Port for the mock agent profile server"
   )
   flags.DEFINE_bool("verbose_http", False, "Whether to log HTTP requests.")
   flags.DEFINE_string(
-      "conformance_input",
-      "test_data/flower_shop/conformance_input.json",
-      "Path to conformance input configuration JSON.",
+    "conformance_input",
+    "test_data/flower_shop/conformance_input.json",
+    "Path to conformance input configuration JSON.",
   )
   flags.DEFINE_string(
-      "test_data_dir",
-      "test_data/flower_shop",
-      "Directory containing test CSV data.",
+    "test_data_dir",
+    "test_data/flower_shop",
+    "Directory containing test CSV data.",
   )
 except flags.DuplicateFlagError:
   pass
@@ -87,19 +91,20 @@ class TestData:
   """Holder for loaded test data."""
 
   def __init__(self) -> None:
-    self.payment_instruments: List[Dict[str, Any]] = []
-    self.addresses: List[Dict[str, Any]] = []
+    """Initialize TestData."""
+    self.payment_instruments: list[dict[str, Any]] = []
+    self.addresses: list[dict[str, Any]] = []
 
   def load(self, data_dir: str) -> None:
-    """Loads data from CSV files in the given directory."""
-    pi_path = os.path.join(data_dir, "payment_instruments.csv")
-    if os.path.exists(pi_path):
-      with open(pi_path, "r") as f:
+    """Load data from CSV files in the given directory."""
+    pi_path = Path(data_dir) / "payment_instruments.csv"
+    if pi_path.exists():
+      with pi_path.open() as f:
         self.payment_instruments = list(csv.DictReader(f))
 
-    addr_path = os.path.join(data_dir, "addresses.csv")
-    if os.path.exists(addr_path):
-      with open(addr_path, "r") as f:
+    addr_path = Path(data_dir) / "addresses.csv"
+    if addr_path.exists():
+      with addr_path.open() as f:
         self.addresses = list(csv.DictReader(f))
 
 
@@ -108,9 +113,9 @@ test_data = TestData()
 
 
 def get_headers(
-    idempotency_key: str | None = None, request_id: str | None = None
-) -> Dict[str, str]:
-  """Generates headers for UCP requests.
+  idempotency_key: str | None = None, request_id: str | None = None
+) -> dict[str, str]:
+  """Generate headers for UCP requests.
 
   Args:
       idempotency_key: Optional specific idempotency key.
@@ -118,73 +123,76 @@ def get_headers(
 
   Returns:
       A dictionary of HTTP headers including UCP-Agent, signature, and keys.
+
   """
-  profile_url = f"http://localhost:{FLAGS.mock_agent_port}{AgentProfileServer.PROFILE_PATH}"
+  profile_url = (
+    f"http://localhost:{FLAGS.mock_agent_port}{AgentProfileServer.PROFILE_PATH}"
+  )
   return {
-      "UCP-Agent": f'profile="{profile_url}"',
-      "request-signature": "test",
-      "idempotency-key": idempotency_key or str(uuid.uuid4()),
-      "request-id": request_id or str(uuid.uuid4()),
+    "UCP-Agent": f'profile="{profile_url}"',
+    "request-signature": "test",
+    "idempotency-key": idempotency_key or str(uuid.uuid4()),
+    "request-id": request_id or str(uuid.uuid4()),
   }
 
 
 def get_valid_payment_payload(
-    instrument_id: str = "instr_1", address_id: str = "addr_1"
-) -> Dict[str, Any]:
-  """Returns a valid payment payload using loaded test data."""
+  instrument_id: str = "instr_1", address_id: str = "addr_1"
+) -> dict[str, Any]:
+  """Return a valid payment payload using loaded test data."""
   # Find instrument
   instr_data = next(
-      (pi for pi in test_data.payment_instruments if pi["id"] == instrument_id),
-      None,
+    (pi for pi in test_data.payment_instruments if pi["id"] == instrument_id),
+    None,
   )
   if not instr_data:
     # Fallback to hardcoded if not loaded (e.g. unit tests without files)
     instr_data = {
-        "id": "instr_1",
-        "type": "card",
-        "brand": "Visa",
-        "last_digits": "1234",
-        "token": "success_token",
-        "handler_id": "mock_payment_handler",
+      "id": "instr_1",
+      "type": "card",
+      "brand": "Visa",
+      "last_digits": "1234",
+      "token": "success_token",
+      "handler_id": "mock_payment_handler",
     }
 
   # Find address
   addr_data = next(
-      (a for a in test_data.addresses if a["id"] == address_id), None
+    (a for a in test_data.addresses if a["id"] == address_id), None
   )
   if not addr_data:
     addr_data = {
-        "street_address": "123 Main St",
-        "city": "Anytown",
-        "state": "CA",
-        "postal_code": "12345",
-        "country": "US",
+      "street_address": "123 Main St",
+      "city": "Anytown",
+      "state": "CA",
+      "postal_code": "12345",
+      "country": "US",
     }
 
   # Construct Billing Address
   billing_address = {
-      "street_address": addr_data.get("street_address"),
-      "address_locality": addr_data.get("city"),
-      "address_region": addr_data.get("state"),
-      "address_country": addr_data.get("country"),
-      "postal_code": addr_data.get("postal_code"),
+    "street_address": addr_data.get("street_address"),
+    "address_locality": addr_data.get("city"),
+    "address_region": addr_data.get("state"),
+    "address_country": addr_data.get("country"),
+    "postal_code": addr_data.get("postal_code"),
   }
 
   # Use Pydantic model to validate/construct
   instr_model = card_payment_instrument.CardPaymentInstrument(
-      id=instr_data["id"],
-      handler_id=instr_data["handler_id"],
-      handler_name=instr_data["handler_id"],  # Assuming same for mock
-      type=instr_data["type"],
-      brand=instr_data["brand"],
-      last_digits=instr_data["last_digits"],
-      credential={"type": "token", "token": instr_data["token"]},
-      billing_address=billing_address,
+    id=instr_data["id"],
+    handler_id=instr_data["handler_id"],
+    handler_name=instr_data["handler_id"],  # Assuming same for mock
+    type=instr_data["type"],
+    brand=instr_data["brand"],
+    last_digits=instr_data["last_digits"],
+    credential={"type": "token", "token": instr_data["token"]},
+    billing_address=billing_address,
   )
 
   return {
-      "payment_data": instr_model.model_dump(mode="json", exclude_none=True),
-      "risk_signals": {},
+    "payment_data": instr_model.model_dump(mode="json", exclude_none=True),
+    "risk_signals": {},
   }
 
 
@@ -194,20 +202,21 @@ class AgentProfileServer:
   PROFILE_PATH = "/profiles/shopping-agent.json"
 
   def __init__(self, *, port: int, webhook_port: int):
-    """Initializes the AgentProfileServer.
+    """Initialize the AgentProfileServer.
 
     Args:
       port: The port to listen on.
       webhook_port: The port where the webhook server is listening.
+
     """
     self.port = port
     self.webhook_port = webhook_port
     self.app = FastAPI()
 
     # Resolve and pre-read the profile template to avoid repeated file I/O
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    self.profile_path = os.path.join(current_dir, "shopping-agent-test.json")
-    with open(self.profile_path, "r") as f:
+    current_dir = Path(__file__).resolve().parent
+    self.profile_path = current_dir / "shopping-agent-test.json"
+    with self.profile_path.open() as f:
       self._profile_template = f.read()
 
     self._setup_routes()
@@ -215,27 +224,27 @@ class AgentProfileServer:
     self._thread: threading.Thread | None
 
   def _setup_routes(self) -> None:
-    """Sets up the routes for the mock agent server."""
+    """Set up the routes for the mock agent server."""
 
     @self.app.get(self.PROFILE_PATH, response_model=None)
     async def get_profile() -> JSONResponse:
-      """Returns the agent profile with the correct webhook port injected."""
+      """Return the agent profile with the correct webhook port injected."""
       # Dynamically inject the correct webhook port into the cached template
       content = self._profile_template.replace(
-          "{webhook_port}", str(self.webhook_port)
+        "{webhook_port}", str(self.webhook_port)
       )
       content_dict = json.loads(content)
       return JSONResponse(content=content_dict)
 
     @self.app.get("/healthz")
-    async def health_check() -> Dict[str, str]:
-      """Returns a simple health check response."""
+    async def health_check() -> dict[str, str]:
+      """Return a simple health check response."""
       return {"status": "ok"}
 
   def start(self) -> None:
-    """Starts the mock server in a background thread."""
+    """Start the mock server in a background thread."""
     config = uvicorn.Config(
-        self.app, host="0.0.0.0", port=self.port, log_level="error"
+      self.app, host="0.0.0.0", port=self.port, log_level="error"
     )
     self._server = uvicorn.Server(config)
     self._thread = threading.Thread(target=self._server.run, daemon=True)
@@ -245,8 +254,8 @@ class AgentProfileServer:
       try:
         with httpx.Client() as client:
           if (
-              client.get(f"http://localhost:{self.port}/healthz").status_code
-              == 200
+            client.get(f"http://localhost:{self.port}/healthz").status_code
+            == 200
           ):
             break
       except httpx.ConnectError:
@@ -255,7 +264,7 @@ class AgentProfileServer:
       raise RuntimeError(f"Server failed to start on port {self.port}")
 
   def stop(self) -> None:
-    """Stops the mock server."""
+    """Stop the mock server."""
     if self._server is not None:
       self._server.should_exit = True
       if self._thread is not None:
@@ -266,37 +275,38 @@ class MockWebhookServer:
   """A background mock webhook server that records incoming events."""
 
   def __init__(self, port: int):
-    """Initializes the MockWebhookServer.
+    """Initialize the MockWebhookServer.
 
     Args:
       port: The port to listen on.
+
     """
     self.port = port
     self.app = FastAPI()
-    self.events: List[Dict[str, Any]] = []
+    self.events: list[dict[str, Any]] = []
     self._setup_routes()
     self._server: uvicorn.Server | None
     self._thread: threading.Thread | None
 
   def _setup_routes(self) -> None:
-    """Sets up the routes for the mock server."""
+    """Set up the routes for the mock server."""
 
     @self.app.post("/webhooks/partners/{partner_id}/events/order")
-    async def order_event(partner_id: str, request: Request) -> Dict[str, str]:
-      """Records an incoming order event."""
+    async def order_event(partner_id: str, request: Request) -> dict[str, str]:
+      """Record an incoming order event."""
       payload = await request.json()
       self.events.append({"partner_id": partner_id, "payload": payload})
       return {"status": "ok"}
 
     @self.app.get("/healthz")
-    async def health_check() -> Dict[str, str]:
-      """Returns a simple health check response."""
+    async def health_check() -> dict[str, str]:
+      """Return a simple health check response."""
       return {"status": "ok"}
 
   def start(self) -> None:
-    """Starts the mock server in a background thread."""
+    """Start the mock server in a background thread."""
     config = uvicorn.Config(
-        self.app, host="0.0.0.0", port=self.port, log_level="error"
+      self.app, host="0.0.0.0", port=self.port, log_level="error"
     )
     self._server = uvicorn.Server(config)
     self._thread = threading.Thread(target=self._server.run, daemon=True)
@@ -306,8 +316,8 @@ class MockWebhookServer:
       try:
         with httpx.Client() as client:
           if (
-              client.get(f"http://localhost:{self.port}/healthz").status_code
-              == 200
+            client.get(f"http://localhost:{self.port}/healthz").status_code
+            == 200
           ):
             break
       except httpx.ConnectError:
@@ -316,14 +326,14 @@ class MockWebhookServer:
       raise RuntimeError(f"Server failed to start on port {self.port}")
 
   def stop(self) -> None:
-    """Stops the mock server."""
+    """Stop the mock server."""
     if self._server is not None:
       self._server.should_exit = True
       if self._thread is not None:
         self._thread.join(timeout=5)
 
   def clear_events(self) -> None:
-    """Clears all recorded events."""
+    """Clear all recorded events."""
     self.events = []
 
 
@@ -331,7 +341,7 @@ class IntegrationTestBase(absltest.TestCase):
   """Base class for UCP integration tests providing setup and helper methods."""
 
   def setUp(self) -> None:
-    """Sets up the test case, including clients and mock servers."""
+    """Set up the test case, including clients and mock servers."""
     super().setUp()
     self.base_url = FLAGS.server_url
     self.client = httpx.Client(base_url=self.base_url)
@@ -345,12 +355,12 @@ class IntegrationTestBase(absltest.TestCase):
 
     # Load conformance input configuration
     try:
-      with open(FLAGS.conformance_input, "r") as f:
+      with Path(FLAGS.conformance_input).open() as f:
         self.conformance_config = json.load(f)
     except FileNotFoundError:
       logging.warning(
-          "Conformance input file not found at %s. Using defaults.",
-          FLAGS.conformance_input,
+        "Conformance input file not found at %s. Using defaults.",
+        FLAGS.conformance_input,
       )
       self.conformance_config = {}
 
@@ -358,7 +368,7 @@ class IntegrationTestBase(absltest.TestCase):
     try:
       # Resolve relative to this file if not absolute
       data_dir = FLAGS.test_data_dir
-      if not os.path.isabs(data_dir):
+      if not Path(data_dir).is_absolute():
         # Assumption: run from where this file is reachable via relative path
         # Actually, FLAGS.test_data_dir is passed by run_conformance.sh
         # Let's try to resolve it.
@@ -369,28 +379,28 @@ class IntegrationTestBase(absltest.TestCase):
 
     # Start the agent profile server
     self.agent_server = AgentProfileServer(
-        port=FLAGS.mock_agent_port, webhook_port=FLAGS.mock_webhook_port
+      port=FLAGS.mock_agent_port, webhook_port=FLAGS.mock_webhook_port
     )
     self.agent_server.start()
 
   def tearDown(self) -> None:
-    """Tears down the test case, stopping servers and clients."""
+    """Tear down the test case, stopping servers and clients."""
     self.client.close()
     if hasattr(self, "agent_server"):
       self.agent_server.stop()
     super().tearDown()
 
   def create_checkout_payload(
-      self,
-      quantity=1,
-      item_id: Optional[str] = None,
-      title: Optional[str] = None,
-      currency: Optional[str] = None,
-      handlers=None,
-      buyer: Optional[Dict[str, Any]] = None,
-      include_fulfillment: bool = True,
+    self,
+    quantity=1,
+    item_id: str | None = None,
+    title: str | None = None,
+    currency: str | None = None,
+    handlers=None,
+    buyer: dict[str, Any] | None = None,
+    include_fulfillment: bool = True,
   ) -> checkout_create_req.CheckoutCreateRequest:
-    """Creates a valid checkout creation payload.
+    """Create a valid checkout creation payload.
 
     Args:
         quantity: Number of items to purchase. Defaults to 1.
@@ -404,12 +414,13 @@ class IntegrationTestBase(absltest.TestCase):
 
     Returns:
         A CheckoutCreateRequest object populated with the specified data.
+
     """
     # Load defaults from config if not provided
     default_item = (
-        self.conformance_config.get("items", [{}])[0]
-        if self.conformance_config
-        else {}
+      self.conformance_config.get("items", [{}])[0]
+      if self.conformance_config
+      else {}
     )
 
     if item_id is None:
@@ -421,65 +432,63 @@ class IntegrationTestBase(absltest.TestCase):
 
     if handlers is None:
       handlers = [
-          payment_handler_resp.PaymentHandlerResponse(
-              id="google_pay",
-              name="google.pay",
-              version="2026-01-11",
-              spec="https://example.com/spec",
-              config_schema="https://example.com/schema",
-              instrument_schemas=["https://example.com/instrument_schema"],
-              config={},
-          )
+        payment_handler_resp.PaymentHandlerResponse(
+          id="google_pay",
+          name="google.pay",
+          version="2026-01-11",
+          spec="https://example.com/spec",
+          config_schema="https://example.com/schema",
+          instrument_schemas=["https://example.com/instrument_schema"],
+          config={},
+        )
       ]
 
     item = item_create_req.ItemCreateRequest(id=item_id, title=title)
     line_item = line_item_create_req.LineItemCreateRequest(
-        quantity=quantity, item=item
+      quantity=quantity, item=item
     )
 
     # PaymentCreateRequest allows extra fields, so passing handlers is valid
     payment = payment_create_req.PaymentCreateRequest(
-        instruments=[],
-        selected_instrument_id="instr_1",
-        handlers=[
-            h.model_dump(mode="json", exclude_none=True) for h in handlers
-        ],
+      instruments=[],
+      selected_instrument_id="instr_1",
+      handlers=[h.model_dump(mode="json", exclude_none=True) for h in handlers],
     )
 
     fulfillment = None
     if include_fulfillment:
       # Hierarchical Fulfillment Construction
       destination = fulfillment_destination_req.FulfillmentDestinationRequest(
-          root=shipping_destination_req.ShippingDestinationRequest(
-              id="dest_1", address_country="US"
-          )
+        root=shipping_destination_req.ShippingDestinationRequest(
+          id="dest_1", address_country="US"
+        )
       )
       group = fulfillment_group_create_req.FulfillmentGroupCreateRequest(
-          selected_option_id="std-ship"
+        selected_option_id="std-ship"
       )
       method = fulfillment_method_create_req.FulfillmentMethodCreateRequest(
-          type="shipping",
-          destinations=[destination],
-          selected_destination_id="dest_1",
-          groups=[group],
+        type="shipping",
+        destinations=[destination],
+        selected_destination_id="dest_1",
+        groups=[group],
       )
       fulfillment = Fulfillment(
-          root=fulfillment_req.FulfillmentRequest(methods=[method])
+        root=fulfillment_req.FulfillmentRequest(methods=[method])
       )
 
     return checkout_create_req.CheckoutCreateRequest(
-        id=str(uuid.uuid4()),
-        currency=currency,
-        line_items=[line_item],
-        payment=payment,
-        buyer=buyer,
-        fulfillment=fulfillment,
+      id=str(uuid.uuid4()),
+      currency=currency,
+      line_items=[line_item],
+      payment=payment,
+      buyer=buyer,
+      fulfillment=fulfillment,
     )
 
   def get_headers(
-      self, idempotency_key: str | None = None, request_id: str | None = None
-  ) -> Dict[str, str]:
-    """Generates headers for UCP requests (instance method).
+    self, idempotency_key: str | None = None, request_id: str | None = None
+  ) -> dict[str, str]:
+    """Generate headers for UCP requests (instance method).
 
     Args:
         idempotency_key: Optional specific idempotency key.
@@ -487,13 +496,14 @@ class IntegrationTestBase(absltest.TestCase):
 
     Returns:
         A dictionary of HTTP headers including UCP-Agent, signature, and keys.
+
     """
     return get_headers(idempotency_key, request_id)
 
   def assert_response_status(
-      self, response: httpx.Response, expected_code: int | list[int]
+    self, response: httpx.Response, expected_code: int | list[int]
   ) -> None:
-    """Asserts that the response status code matches the expected code(s).
+    """Assert that the response status code matches the expected code(s).
 
     Args:
         response: The httpx response object.
@@ -502,6 +512,7 @@ class IntegrationTestBase(absltest.TestCase):
 
     Raises:
         AssertionError: If the response status code is not in expected_code.
+
     """
     if isinstance(expected_code, int):
       expected_codes = [expected_code]
@@ -509,26 +520,26 @@ class IntegrationTestBase(absltest.TestCase):
       expected_codes = expected_code
 
     self.assertIn(
-        response.status_code,
-        expected_codes,
-        msg=(
-            f"Expected status {expected_code}, got {response.status_code}."
-            f" Resp: {response.text}"
-        ),
+      response.status_code,
+      expected_codes,
+      msg=(
+        f"Expected status {expected_code}, got {response.status_code}."
+        f" Resp: {response.text}"
+      ),
     )
 
   def create_checkout_session(
-      self,
-      quantity: int = 1,
-      item_id: Optional[str] = None,
-      title: Optional[str] = None,
-      currency: Optional[str] = None,
-      handlers: list[Any] | None = None,
-      buyer: Optional[Dict[str, Any]] = None,
-      select_fulfillment: bool = True,
-      headers: Dict[str, str] | None = None,
+    self,
+    quantity: int = 1,
+    item_id: str | None = None,
+    title: str | None = None,
+    currency: str | None = None,
+    handlers: list[Any] | None = None,
+    buyer: dict[str, Any] | None = None,
+    select_fulfillment: bool = True,
+    headers: dict[str, str] | None = None,
   ) -> Any:
-    """Creates a checkout session and returns the response JSON.
+    """Create a checkout session and return the response JSON.
 
     Args:
         quantity: Number of items to purchase. Defaults to 1.
@@ -544,15 +555,16 @@ class IntegrationTestBase(absltest.TestCase):
 
     Returns:
         The JSON response dictionary from the create request.
+
     """
     create_payload = self.create_checkout_payload(
-        quantity=quantity,
-        item_id=item_id,
-        title=title,
-        currency=currency,
-        handlers=handlers,
-        buyer=buyer,
-        include_fulfillment=select_fulfillment,
+      quantity=quantity,
+      item_id=item_id,
+      title=title,
+      currency=currency,
+      handlers=handlers,
+      buyer=buyer,
+      include_fulfillment=select_fulfillment,
     )
 
     request_headers = self.get_headers()
@@ -560,11 +572,11 @@ class IntegrationTestBase(absltest.TestCase):
       request_headers.update(headers)
 
     response = self.client.post(
-        "/checkout-sessions",
-        json=create_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=request_headers,
+      "/checkout-sessions",
+      json=create_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=request_headers,
     )
     self.assert_response_status(response, [200, 201])
     checkout_data = response.json()
@@ -575,16 +587,17 @@ class IntegrationTestBase(absltest.TestCase):
     return checkout_data
 
   def ensure_fulfillment_ready(self, checkout_id: str) -> Any:
-    """Ensures a fulfillment option is selected for the checkout.
+    """Ensure a fulfillment option is selected for the checkout.
 
     Args:
         checkout_id: The ID of the checkout to check and update.
 
     Returns:
         The updated checkout data dictionary.
+
     """
     response = self.client.get(
-        f"/checkout-sessions/{checkout_id}", headers=self.get_headers()
+      f"/checkout-sessions/{checkout_id}", headers=self.get_headers()
     )
     checkout_data = response.json()
 
@@ -595,11 +608,9 @@ class IntegrationTestBase(absltest.TestCase):
       method = data["fulfillment"]["methods"][0]
       if not method.get("selected_destination_id"):
         return False
-      if not method.get("groups") or not method["groups"][0].get(
-          "selected_option_id"
-      ):
-        return False
-      return True
+      return method.get("groups") and method["groups"][0].get(
+        "selected_option_id"
+      )
 
     if is_ready(checkout_data):
       return checkout_data
@@ -608,62 +619,61 @@ class IntegrationTestBase(absltest.TestCase):
 
     # 1. Trigger fulfillment with a default address if none exists
     has_destinations = (
-        checkout_data.get("fulfillment")
-        and checkout_data["fulfillment"].get("methods")
-        and checkout_data["fulfillment"]["methods"][0].get("destinations")
+      checkout_data.get("fulfillment")
+      and checkout_data["fulfillment"].get("methods")
+      and checkout_data["fulfillment"]["methods"][0].get("destinations")
     )
 
     if not has_destinations:
       # Inject a default US address
       address = {
-          "id": "dest_default",
-          "street_address": "123 Default St",
-          "address_locality": "City",
-          "address_region": "State",
-          "postal_code": "12345",
-          "address_country": "US",
+        "id": "dest_default",
+        "street_address": "123 Default St",
+        "address_locality": "City",
+        "address_region": "State",
+        "postal_code": "12345",
+        "address_country": "US",
       }
       # Preserve method ID if exists
       method_id = None
       if checkout_data.get("fulfillment") and checkout_data["fulfillment"].get(
-          "methods"
+        "methods"
       ):
         method_id = checkout_data["fulfillment"]["methods"][0].get("id")
 
       method_payload = {
-          "type": "shipping",
-          "destinations": [address],
-          "selected_destination_id": "dest_default",
+        "type": "shipping",
+        "destinations": [address],
+        "selected_destination_id": "dest_default",
       }
       if method_id:
         method_payload["id"] = method_id
 
       checkout_data = self.update_checkout_session(
-          checkout_obj,
-          fulfillment={"methods": [method_payload]},
+        checkout_obj,
+        fulfillment={"methods": [method_payload]},
       )
       checkout_obj = f_models.Checkout(**checkout_data)
 
     # 2. Select Destination (if not already selected)
     method = checkout_data["fulfillment"]["methods"][0]
-    if not method.get("selected_destination_id"):
-      if method.get("destinations"):
-        dest_id = method["destinations"][0]["id"]
+    if not method.get("selected_destination_id") and method.get("destinations"):
+      dest_id = method["destinations"][0]["id"]
 
-        # Construct update preserving destinations
-        method_payload = method.copy()
-        # method is a dict from json response
-        # We need to ensure we send back valid update data
-        # Response might have fields not valid for update?
-        # Usually safe to send back what we got + changes for this simple server
-        method_payload["selected_destination_id"] = dest_id
-        # Ensure we keep destinations
+      # Construct update preserving destinations
+      method_payload = method.copy()
+      # method is a dict from json response
+      # We need to ensure we send back valid update data
+      # Response might have fields not valid for update?
+      # Usually safe to send back what we got + changes for this simple server
+      method_payload["selected_destination_id"] = dest_id
+      # Ensure we keep destinations
 
-        checkout_data = self.update_checkout_session(
-            checkout_obj,
-            fulfillment={"methods": [method_payload]},
-        )
-        checkout_obj = f_models.Checkout(**checkout_data)
+      checkout_data = self.update_checkout_session(
+        checkout_obj,
+        fulfillment={"methods": [method_payload]},
+      )
+      checkout_obj = f_models.Checkout(**checkout_data)
 
     # 3. Select Option
     method = checkout_data["fulfillment"]["methods"][0]
@@ -674,26 +684,27 @@ class IntegrationTestBase(absltest.TestCase):
           has_selection = True
           break
 
-    if not has_selection:
-      if method.get("groups") and method["groups"][0].get("options"):
-        option_id = method["groups"][0]["options"][0]["id"]
+    if not has_selection and (
+      method.get("groups") and method["groups"][0].get("options")
+    ):
+      option_id = method["groups"][0]["options"][0]["id"]
 
-        # Update group
-        method_payload = method.copy()
-        # Ensure groups is a list of dicts
-        method_payload["groups"][0]["selected_option_id"] = option_id
+      # Update group
+      method_payload = method.copy()
+      # Ensure groups is a list of dicts
+      method_payload["groups"][0]["selected_option_id"] = option_id
 
-        checkout_data = self.update_checkout_session(
-            checkout_obj,
-            fulfillment={"methods": [method_payload]},
-        )
+      checkout_data = self.update_checkout_session(
+        checkout_obj,
+        fulfillment={"methods": [method_payload]},
+      )
 
     return checkout_data
 
   def complete_checkout_session(
-      self, checkout_id: str, payment_payload: Dict[str, Any] | None = None
+    self, checkout_id: str, payment_payload: dict[str, Any] | None = None
   ) -> Any:
-    """Completes a checkout session.
+    """Complete a checkout session.
 
     Args:
         checkout_id: The ID of the checkout to complete.
@@ -702,6 +713,7 @@ class IntegrationTestBase(absltest.TestCase):
 
     Returns:
         The JSON response dictionary from the complete request.
+
     """
     # Ensure fulfillment is set (required by server)
     self.ensure_fulfillment_ready(checkout_id)
@@ -710,15 +722,15 @@ class IntegrationTestBase(absltest.TestCase):
       payment_payload = get_valid_payment_payload()
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=payment_payload,
-        headers=self.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=payment_payload,
+      headers=self.get_headers(),
     )
     self.assert_response_status(response, 200)
     return response.json()
 
   def create_completed_order(self) -> str:
-    """Orchestrates checkout creation and completion.
+    """Orchestrate checkout creation and completion.
 
     This helper combines create_checkout_session and complete_checkout_session
     to quickly reach a "completed order" state for testing post-order
@@ -726,6 +738,7 @@ class IntegrationTestBase(absltest.TestCase):
 
     Returns:
         The 'order_id' from the completion response.
+
     """
     checkout_data = self.create_checkout_session()
     checkout_id = checkout_data["id"]
@@ -733,18 +746,18 @@ class IntegrationTestBase(absltest.TestCase):
     return complete_data["order"]["id"]
 
   def update_checkout_session(
-      self,
-      checkout_obj: Any,
-      currency: str | None = None,
-      line_items: list[Any] | None = None,
-      payment: Any | None = None,
-      buyer: Any | None = None,
-      fulfillment: Any | None = None,
-      discounts: Any | None = None,
-      platform: Any | None = None,
-      headers: Dict[str, str] | None = None,
+    self,
+    checkout_obj: Any,
+    currency: str | None = None,
+    line_items: list[Any] | None = None,
+    payment: Any | None = None,
+    buyer: Any | None = None,
+    fulfillment: Any | None = None,
+    discounts: Any | None = None,
+    platform: Any | None = None,
+    headers: dict[str, str] | None = None,
   ) -> Any:
-    """Updates a checkout session.
+    """Update a checkout session.
 
     Constructs a partial update request based on the existing checkout object
     and any provided override fields.
@@ -762,6 +775,7 @@ class IntegrationTestBase(absltest.TestCase):
 
     Returns:
         The JSON response dictionary from the update request.
+
     """
     # Default to existing values if not provided
     currency = currency if currency is not None else checkout_obj.currency
@@ -771,37 +785,37 @@ class IntegrationTestBase(absltest.TestCase):
       line_items = []
       for li in checkout_obj.line_items:
         item_update = item_update_req.ItemUpdateRequest(
-            id=li.item.id,
-            title=li.item.title,
+          id=li.item.id,
+          title=li.item.title,
         )
         line_items.append(
-            line_item_update_req.LineItemUpdateRequest(
-                id=li.id,
-                item=item_update,
-                quantity=li.quantity,
-            )
+          line_item_update_req.LineItemUpdateRequest(
+            id=li.id,
+            item=item_update,
+            quantity=li.quantity,
+          )
         )
 
     # Construct Payment
     if payment is None:
       payment = payment_update_req.PaymentUpdateRequest(
-          selected_instrument_id=checkout_obj.payment.selected_instrument_id,
-          instruments=checkout_obj.payment.instruments,
-          handlers=[
-              h.model_dump(mode="json", exclude_none=True)
-              for h in checkout_obj.payment.handlers
-          ],
+        selected_instrument_id=checkout_obj.payment.selected_instrument_id,
+        instruments=checkout_obj.payment.instruments,
+        handlers=[
+          h.model_dump(mode="json", exclude_none=True)
+          for h in checkout_obj.payment.handlers
+        ],
       )
 
     update_payload = UnifiedUpdate(
-        id=checkout_obj.id,
-        currency=currency,
-        line_items=line_items,
-        payment=payment,
-        buyer=buyer,
-        fulfillment=fulfillment,
-        discounts=discounts,
-        platform=platform,
+      id=checkout_obj.id,
+      currency=currency,
+      line_items=line_items,
+      payment=payment,
+      buyer=buyer,
+      fulfillment=fulfillment,
+      discounts=discounts,
+      platform=platform,
     )
 
     request_headers = self.get_headers()
@@ -809,11 +823,11 @@ class IntegrationTestBase(absltest.TestCase):
       request_headers.update(headers)
 
     response = self.client.put(
-        f"/checkout-sessions/{checkout_obj.id}",
-        json=update_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=request_headers,
+      f"/checkout-sessions/{checkout_obj.id}",
+      json=update_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=request_headers,
     )
     self.assert_response_status(response, 200)
     return response.json()

--- a/invalid_input_test.py
+++ b/invalid_input_test.py
@@ -20,7 +20,9 @@ from absl.testing import absltest
 import integration_test_utils
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
 from ucp_sdk.models.schemas.shopping import order
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 
 # Rebuild models to resolve forward references
 checkout.Checkout.model_rebuild(_types_namespace={"PaymentResponse": Payment})
@@ -47,20 +49,20 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order
     response = self.client.get(
-        f"/orders/{order_id}", headers=self.get_headers()
+      f"/orders/{order_id}", headers=self.get_headers()
     )
     order_obj = order.Order(**response.json())
     order_dict = order_obj.model_dump(
-        mode="json", by_alias=True, exclude_none=True
+      mode="json", by_alias=True, exclude_none=True
     )
 
     # Add Adjustment with invalid status
     adj = {
-        "id": f"adj_{uuid.uuid4()}",
-        "type": "refund",
-        "occurred_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        "status": "INVALID_STATUS",  # Invalid literal
-        "amount": 500,
+      "id": f"adj_{uuid.uuid4()}",
+      "type": "refund",
+      "occurred_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+      "status": "INVALID_STATUS",  # Invalid literal
+      "amount": 500,
     }
 
     if order_dict.get("adjustments") is None:
@@ -69,9 +71,9 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Update Order
     resp = self.client.put(
-        f"/orders/{order_id}",
-        json=order_dict,
-        headers=self.get_headers(),
+      f"/orders/{order_id}",
+      json=order_dict,
+      headers=self.get_headers(),
     )
     # Pydantic validation error should result in 422
     self.assert_response_status(resp, 422)
@@ -90,16 +92,16 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
     # Update with unknown discount code using helper
     # The helper preserves existing fields, so we just pass the discount
     resp_json = self.update_checkout_session(
-        checkout_obj, discounts={"codes": ["INVALID_CODE_123"]}
+      checkout_obj, discounts={"codes": ["INVALID_CODE_123"]}
     )
 
     updated_checkout = checkout.Checkout(**resp_json)
     # Verify no discount applied
     discount_total = next(
-        (t for t in updated_checkout.totals if t.type == "discount"), None
+      (t for t in updated_checkout.totals if t.type == "discount"), None
     )
     self.assertIsNone(
-        discount_total, "Unknown discount code should not apply discount"
+      discount_total, "Unknown discount code should not apply discount"
     )
 
   def test_malformed_adjustment_payload(self):
@@ -114,11 +116,11 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order
     response = self.client.get(
-        f"/orders/{order_id}", headers=self.get_headers()
+      f"/orders/{order_id}", headers=self.get_headers()
     )
     order_obj = order.Order(**response.json())
     order_dict = order_obj.model_dump(
-        mode="json", by_alias=True, exclude_none=True
+      mode="json", by_alias=True, exclude_none=True
     )
 
     # Malform the adjustments field (dict instead of list)
@@ -126,9 +128,9 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Update Order
     resp = self.client.put(
-        f"/orders/{order_id}",
-        json=order_dict,
-        headers=self.get_headers(),
+      f"/orders/{order_id}",
+      json=order_dict,
+      headers=self.get_headers(),
     )
 
     self.assert_response_status(resp, 422)

--- a/order_test.py
+++ b/order_test.py
@@ -22,7 +22,9 @@ import integration_test_utils
 from pydantic import AnyUrl
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
 from ucp_sdk.models.schemas.shopping import order
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 from ucp_sdk.models.schemas.shopping.types import adjustment
 from ucp_sdk.models.schemas.shopping.types import fulfillment_event
 
@@ -55,14 +57,14 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order
     response = self.client.get(
-        f"/orders/{order_id}", headers=self.get_headers()
+      f"/orders/{order_id}", headers=self.get_headers()
     )
     self.assert_response_status(response, 200)
 
     order_data = order.Order(**response.json())
     self.assertEqual(order_data.id, order_id, "Order ID mismatch")
     self.assertEqual(
-        order_data.checkout_id, checkout_id, "Checkout ID mismatch"
+      order_data.checkout_id, checkout_id, "Checkout ID mismatch"
     )
 
   def test_order_fulfillment_retrieval(self) -> None:
@@ -81,42 +83,44 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     # Use helper to get a valid address from CSV
     address_data = integration_test_utils.test_data.addresses[0]
     fulfillment_address = {
-        "id": "dest_manual",
-        "full_name": "Jane Doe",
-        "street_address": address_data["street_address"],
-        "address_locality": address_data["city"],
-        "address_region": address_data["state"],
-        "postal_code": address_data["postal_code"],
-        "address_country": address_data["country"],
+      "id": "dest_manual",
+      "full_name": "Jane Doe",
+      "street_address": address_data["street_address"],
+      "address_locality": address_data["city"],
+      "address_region": address_data["state"],
+      "postal_code": address_data["postal_code"],
+      "address_country": address_data["country"],
     }
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [fulfillment_address],
-            "selected_destination_id": "dest_manual",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [fulfillment_address],
+          "selected_destination_id": "dest_manual",
+        }
+      ]
     }
 
     update_payload = {
-        "id": checkout_id,
-        "currency": checkout_obj.currency,
-        "line_items": [
-            {
-                "item": {"id": li.item.id, "title": li.item.title},
-                "quantity": li.quantity,
-                "id": li.id,
-            }
-            for li in checkout_obj.line_items
-        ],
-        "payment": integration_test_utils.get_valid_payment_payload(),
-        "fulfillment": fulfillment_payload,
+      "id": checkout_id,
+      "currency": checkout_obj.currency,
+      "line_items": [
+        {
+          "item": {"id": li.item.id, "title": li.item.title},
+          "quantity": li.quantity,
+          "id": li.id,
+        }
+        for li in checkout_obj.line_items
+      ],
+      "payment": integration_test_utils.get_valid_payment_payload(),
+      "fulfillment": fulfillment_payload,
     }
 
     response = self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload,
-        headers=self.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload,
+      headers=self.get_headers(),
     )
     self.assert_response_status(response, 200)
 
@@ -125,12 +129,12 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     # Check options in hierarchical structure
     options = []
     if (
-        checkout_with_options.fulfillment
-        and checkout_with_options.fulfillment.root.methods
-        and checkout_with_options.fulfillment.root.methods[0].groups
+      checkout_with_options.fulfillment
+      and checkout_with_options.fulfillment.root.methods
+      and checkout_with_options.fulfillment.root.methods[0].groups
     ):
       options = (
-          checkout_with_options.fulfillment.root.methods[0].groups[0].options
+        checkout_with_options.fulfillment.root.methods[0].groups[0].options
       )
 
     self.assertTrue(options, "No options returned")
@@ -141,13 +145,13 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     # Update payload to select option
     # Need to preserve the method structure
     update_payload["fulfillment"]["methods"][0]["groups"] = [
-        {"selected_option_id": option_id}
+      {"selected_option_id": option_id}
     ]
 
     response = self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload,
-        headers=self.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload,
+      headers=self.get_headers(),
     )
     self.assert_response_status(response, 200)
 
@@ -157,19 +161,19 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order and verify fulfillment details
     response = self.client.get(
-        f"/orders/{order_id}", headers=self.get_headers()
+      f"/orders/{order_id}", headers=self.get_headers()
     )
     self.assert_response_status(response, 200)
     order_obj = order.Order(**response.json())
 
     self.assertTrue(
-        order_obj.fulfillment.expectations, "No expectations in order"
+      order_obj.fulfillment.expectations, "No expectations in order"
     )
     # Verify the expectation description matches the selected option title
     self.assertEqual(
-        order_obj.fulfillment.expectations[0].description,
-        options[0].title,
-        "Expectation description mismatch",
+      order_obj.fulfillment.expectations[0].description,
+      options[0].title,
+      "Expectation description mismatch",
     )
 
   def test_order_update(self) -> None:
@@ -189,76 +193,78 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     # Use helper to get a valid address from CSV
     address_data = integration_test_utils.test_data.addresses[0]
     addr = {
-        "id": "dest_manual_2",
-        "full_name": "Jane Doe",
-        "street_address": address_data["street_address"],
-        "address_locality": address_data["city"],
-        "address_region": address_data["state"],
-        "postal_code": address_data["postal_code"],
-        "address_country": address_data["country"],
+      "id": "dest_manual_2",
+      "full_name": "Jane Doe",
+      "street_address": address_data["street_address"],
+      "address_locality": address_data["city"],
+      "address_region": address_data["state"],
+      "postal_code": address_data["postal_code"],
+      "address_country": address_data["country"],
     }
 
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [addr],
-            "selected_destination_id": "dest_manual_2",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [addr],
+          "selected_destination_id": "dest_manual_2",
+        }
+      ]
     }
 
     update_payload = {
-        "id": checkout_id,
-        "currency": checkout_obj.currency,
-        "line_items": [
-            {
-                "item": {"id": li.item.id, "title": li.item.title},
-                "quantity": li.quantity,
-                "id": li.id,
-            }
-            for li in checkout_obj.line_items
-        ],
-        "payment": integration_test_utils.get_valid_payment_payload(),
-        "fulfillment": fulfillment_payload,
+      "id": checkout_id,
+      "currency": checkout_obj.currency,
+      "line_items": [
+        {
+          "item": {"id": li.item.id, "title": li.item.title},
+          "quantity": li.quantity,
+          "id": li.id,
+        }
+        for li in checkout_obj.line_items
+      ],
+      "payment": integration_test_utils.get_valid_payment_payload(),
+      "fulfillment": fulfillment_payload,
     }
 
     resp = self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload,
-        headers=self.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload,
+      headers=self.get_headers(),
     )
     self.assert_response_status(resp, 200)
 
     checkout_resp = resp.json()
     options = []
     if (
-        checkout_resp.get("fulfillment")
-        and checkout_resp["fulfillment"].get("root")  # RootModel serialized?
-        and checkout_resp["fulfillment"]["root"].get("methods")
-        and checkout_resp["fulfillment"]["root"]["methods"][0].get("groups")
+      checkout_resp.get("fulfillment")
+      and checkout_resp["fulfillment"].get("root")  # RootModel serialized?
+      and checkout_resp["fulfillment"]["root"].get("methods")
+      and checkout_resp["fulfillment"]["root"]["methods"][0].get("groups")
     ):
       options = checkout_resp["fulfillment"]["root"]["methods"][0]["groups"][0][
-          "options"
+        "options"
       ]
     elif (
-        checkout_resp.get("fulfillment")
-        and checkout_resp["fulfillment"].get("methods")
-        and checkout_resp["fulfillment"]["methods"][0].get("groups")
+      checkout_resp.get("fulfillment")
+      and checkout_resp["fulfillment"].get("methods")
+      and checkout_resp["fulfillment"]["methods"][0].get("groups")
     ):
       options = checkout_resp["fulfillment"]["methods"][0]["groups"][0][
-          "options"
+        "options"
       ]
 
     self.assertTrue(options)
 
     # Select option
     update_payload["fulfillment"]["methods"][0]["groups"] = [
-        {"selected_option_id": options[0]["id"]}
+      {"selected_option_id": options[0]["id"]}
     ]
 
     self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload,
-        headers=self.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload,
+      headers=self.get_headers(),
     )
 
     # Complete
@@ -272,16 +278,16 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Update Order (Add Shipment Event)
     new_event = fulfillment_event.FulfillmentEvent(
-        id=f"evt_{uuid.uuid4()}",
-        occurred_at=datetime.datetime.now(datetime.timezone.utc),
-        type="shipped",
-        line_items=[
-            fulfillment_event.LineItem(id=li.id, quantity=li.quantity.total)
-            for li in order_obj.line_items
-        ],
-        tracking_number="TRACK123",
-        tracking_url=AnyUrl("http://track.me/123"),
-        description="Shipped via FedEx",
+      id=f"evt_{uuid.uuid4()}",
+      occurred_at=datetime.datetime.now(datetime.timezone.utc),
+      type="shipped",
+      line_items=[
+        fulfillment_event.LineItem(id=li.id, quantity=li.quantity.total)
+        for li in order_obj.line_items
+      ],
+      tracking_number="TRACK123",
+      tracking_url=AnyUrl("http://track.me/123"),
+      description="Shipped via FedEx",
     )
 
     if order_obj.fulfillment.events is None:
@@ -289,20 +295,18 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     order_obj.fulfillment.events.append(new_event)
 
     resp = self.client.put(
-        f"/orders/{order_id}",
-        json=order_obj.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=self.get_headers(),
+      f"/orders/{order_id}",
+      json=order_obj.model_dump(mode="json", by_alias=True, exclude_none=True),
+      headers=self.get_headers(),
     )
     self.assert_response_status(resp, 200)
 
     updated_order = order.Order(**resp.json())
     self.assertTrue(updated_order.fulfillment.events, "No events returned")
     self.assertEqual(
-        updated_order.fulfillment.events[0].tracking_number,
-        "TRACK123",
-        msg="Order event not persisted",
+      updated_order.fulfillment.events[0].tracking_number,
+      "TRACK123",
+      msg="Order event not persisted",
     )
 
   def test_order_adjustments(self) -> None:
@@ -321,12 +325,12 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Add Adjustment
     adj = adjustment.Adjustment(
-        id=f"adj_{uuid.uuid4()}",
-        type="refund",
-        occurred_at=datetime.datetime.now(datetime.timezone.utc),
-        status="pending",
-        amount=500,
-        description="Customer refund request",
+      id=f"adj_{uuid.uuid4()}",
+      type="refund",
+      occurred_at=datetime.datetime.now(datetime.timezone.utc),
+      status="pending",
+      amount=500,
+      description="Customer refund request",
     )
 
     if order_obj.adjustments is None:
@@ -335,11 +339,9 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Update Order
     resp = self.client.put(
-        f"/orders/{order_id}",
-        json=order_obj.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=self.get_headers(),
+      f"/orders/{order_id}",
+      json=order_obj.model_dump(mode="json", by_alias=True, exclude_none=True),
+      headers=self.get_headers(),
     )
     self.assert_response_status(resp, 200)
 

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -18,7 +18,9 @@ from absl.testing import absltest
 import integration_test_utils
 from ucp_sdk.models.discovery.profile_schema import UcpDiscoveryProfile
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 
 # Rebuild models to resolve forward references
 checkout.Checkout.model_rebuild(_types_namespace={"PaymentResponse": Payment})
@@ -48,27 +50,27 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     profile = UcpDiscoveryProfile(**data)
 
     self.assertEqual(
-        profile.ucp.version.root,
-        "2026-01-11",
-        msg="Unexpected UCP version in discovery doc",
+      profile.ucp.version.root,
+      "2026-01-11",
+      msg="Unexpected UCP version in discovery doc",
     )
 
     # Verify Capabilities
     capabilities = {c.name for c in profile.ucp.capabilities}
     expected_capabilities = {
-        "dev.ucp.shopping.checkout",
-        "dev.ucp.shopping.order",
-        "dev.ucp.shopping.refund",
-        "dev.ucp.shopping.return",
-        "dev.ucp.shopping.dispute",
-        "dev.ucp.shopping.discount",
-        "dev.ucp.shopping.fulfillment",
-        "dev.ucp.shopping.buyer_consent",
+      "dev.ucp.shopping.checkout",
+      "dev.ucp.shopping.order",
+      "dev.ucp.shopping.refund",
+      "dev.ucp.shopping.return",
+      "dev.ucp.shopping.dispute",
+      "dev.ucp.shopping.discount",
+      "dev.ucp.shopping.fulfillment",
+      "dev.ucp.shopping.buyer_consent",
     }
     missing_caps = expected_capabilities - capabilities
     self.assertFalse(
-        missing_caps,
-        f"Missing expected capabilities in discovery: {missing_caps}",
+      missing_caps,
+      f"Missing expected capabilities in discovery: {missing_caps}",
     )
 
     # Verify Payment Handlers
@@ -76,14 +78,14 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     expected_handlers = {"google_pay", "mock_payment_handler", "shop_pay"}
     missing_handlers = expected_handlers - handlers
     self.assertFalse(
-        missing_handlers,
-        f"Missing expected payment handlers: {missing_handlers}",
+      missing_handlers,
+      f"Missing expected payment handlers: {missing_handlers}",
     )
 
     # Specific check for Shop Pay config
     shop_pay = next(
-        (h for h in profile.payment.handlers if h.id == "shop_pay"),
-        None,
+      (h for h in profile.payment.handlers if h.id == "shop_pay"),
+      None,
     )
     self.assertIsNotNone(shop_pay, "Shop Pay handler not found")
     self.assertEqual(shop_pay.name, "com.shopify.shop_pay")
@@ -104,22 +106,22 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     headers = integration_test_utils.get_headers()
     headers["UCP-Agent"] = 'profile="..."; version="2026-01-11"'
     response = self.client.post(
-        "/checkout-sessions",
-        json=create_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=headers,
+      "/checkout-sessions",
+      json=create_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=headers,
     )
     self.assert_response_status(response, [200, 201])
 
     # 2. Incompatible Version
     headers["UCP-Agent"] = 'profile="..."; version="2099-01-01"'
     response = self.client.post(
-        "/checkout-sessions",
-        json=create_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=headers,
+      "/checkout-sessions",
+      json=create_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=headers,
     )
     self.assert_response_status(response, 400)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "ucp-sdk",
     "fastapi>=0.109.0",
     "uvicorn[standard]>=0.38.0",
+    "ruff>=0.14.11",
 ]
 
 [dependency-groups]
@@ -29,3 +30,23 @@ packages = ["."]
 [tool.uv.sources]
 # The relative path is stored here
 ucp-sdk = { path = "../sdk/python/", editable = true }
+
+[tool.ruff]
+line-length = 80
+indent-width = 2
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B", "C4", "SIM", "N", "UP", "D", "PTH", "T20"]
+ignore = ["D203", "D213"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+force-sort-within-sections = true
+case-sensitive = true

--- a/simulation_url_security_test.py
+++ b/simulation_url_security_test.py
@@ -25,8 +25,8 @@ class SecurityTest(integration_test_utils.IntegrationTestBase):
     """Test access without the secret header returns 403."""
     order_id = self.create_completed_order()
     response = self.client.post(
-        f"/testing/simulate-shipping/{order_id}",
-        headers=self.get_headers(),  # Standard headers only
+      f"/testing/simulate-shipping/{order_id}",
+      headers=self.get_headers(),  # Standard headers only
     )
     self.assert_response_status(response, 403)
 
@@ -36,8 +36,8 @@ class SecurityTest(integration_test_utils.IntegrationTestBase):
     headers = self.get_headers()
     headers["Simulation-Secret"] = "for-sure-incorrect-secret"
     response = self.client.post(
-        f"/testing/simulate-shipping/{order_id}",
-        headers=headers,
+      f"/testing/simulate-shipping/{order_id}",
+      headers=headers,
     )
     self.assert_response_status(response, 403)
 
@@ -46,11 +46,11 @@ class SecurityTest(integration_test_utils.IntegrationTestBase):
     order_id = self.create_completed_order()
     headers = self.get_headers()
     headers["Simulation-Secret"] = (
-        integration_test_utils.FLAGS.simulation_secret
+      integration_test_utils.FLAGS.simulation_secret
     )
     response = self.client.post(
-        f"/testing/simulate-shipping/{order_id}",
-        headers=headers,
+      f"/testing/simulate-shipping/{order_id}",
+      headers=headers,
     )
     self.assert_response_status(response, 200)
 

--- a/validation_test.py
+++ b/validation_test.py
@@ -19,7 +19,9 @@ import integration_test_utils
 from ucp_sdk.models.schemas.shopping import checkout_update_req
 from ucp_sdk.models.schemas.shopping import fulfillment_resp as checkout
 from ucp_sdk.models.schemas.shopping import payment_update_req
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 from ucp_sdk.models.schemas.shopping.types import item_update_req
 from ucp_sdk.models.schemas.shopping.types import line_item_update_req
 
@@ -47,28 +49,28 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
     """
     # Get out of stock item from config
     out_of_stock_item = self.conformance_config.get(
-        "out_of_stock_item",
-        {"id": "out_of_stock_item_1", "title": "Out of Stock Item"},
+      "out_of_stock_item",
+      {"id": "out_of_stock_item_1", "title": "Out of Stock Item"},
     )
 
     create_payload = self.create_checkout_payload(
-        item_id=out_of_stock_item["id"],
-        title=out_of_stock_item["title"],
+      item_id=out_of_stock_item["id"],
+      title=out_of_stock_item["title"],
     )
 
     response = self.client.post(
-        "/checkout-sessions",
-        json=create_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=integration_test_utils.get_headers(),
+      "/checkout-sessions",
+      json=create_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 400)
     self.assertIn(
-        "Insufficient stock",
-        response.text,
-        msg="Expected 'Insufficient stock' message",
+      "Insufficient stock",
+      response.text,
+      msg="Expected 'Insufficient stock' message",
     )
 
   def test_update_inventory_validation(self) -> None:
@@ -85,41 +87,41 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
 
     # Update to excessive quantity (e.g. 10000)
     item_update = item_update_req.ItemUpdateRequest(
-        id=checkout_obj.line_items[0].item.id,
-        title=checkout_obj.line_items[0].item.title,
+      id=checkout_obj.line_items[0].item.id,
+      title=checkout_obj.line_items[0].item.title,
     )
     line_item_update = line_item_update_req.LineItemUpdateRequest(
-        id=checkout_obj.line_items[0].id,
-        item=item_update,
-        quantity=10001,
+      id=checkout_obj.line_items[0].id,
+      item=item_update,
+      quantity=10001,
     )
     payment_update = payment_update_req.PaymentUpdateRequest(
-        selected_instrument_id=checkout_obj.payment.selected_instrument_id,
-        instruments=checkout_obj.payment.instruments,
-        handlers=[
-            h.model_dump(mode="json", exclude_none=True)
-            for h in checkout_obj.payment.handlers
-        ],
+      selected_instrument_id=checkout_obj.payment.selected_instrument_id,
+      instruments=checkout_obj.payment.instruments,
+      handlers=[
+        h.model_dump(mode="json", exclude_none=True)
+        for h in checkout_obj.payment.handlers
+      ],
     )
 
     update_payload = checkout_update_req.CheckoutUpdateRequest(
-        id=checkout_id,
-        currency=checkout_obj.currency,
-        line_items=[line_item_update],
-        payment=payment_update,
+      id=checkout_id,
+      currency=checkout_obj.currency,
+      line_items=[line_item_update],
+      payment=payment_update,
     )
 
     response = self.client.put(
-        f"/checkout-sessions/{checkout_id}",
-        json=update_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}",
+      json=update_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 400)
     self.assertIn(
-        "stock", response.text.lower(), msg="Expected 'stock' message"
+      "stock", response.text.lower(), msg="Expected 'stock' message"
     )
 
   def test_product_not_found(self) -> None:
@@ -131,26 +133,26 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
     was not found.
     """
     non_existent_item = self.conformance_config.get(
-        "non_existent_item",
-        {"id": "non_existent_item_1", "title": "Non-existent Item"},
+      "non_existent_item",
+      {"id": "non_existent_item_1", "title": "Non-existent Item"},
     )
 
     create_payload = self.create_checkout_payload(
-        item_id=non_existent_item["id"],
-        title=non_existent_item["title"],
+      item_id=non_existent_item["id"],
+      title=non_existent_item["title"],
     )
 
     response = self.client.post(
-        "/checkout-sessions",
-        json=create_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=integration_test_utils.get_headers(),
+      "/checkout-sessions",
+      json=create_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 400)
     self.assertIn(
-        "not found", response.text.lower(), msg="Expected 'not found' message"
+      "not found", response.text.lower(), msg="Expected 'not found' message"
     )
 
   def test_payment_failure(self) -> None:
@@ -167,13 +169,13 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
     # Use the helper to get valid structure, but request the failing instrument
     # 'instr_fail' is loaded from payment_instruments.csv
     payment_payload = integration_test_utils.get_valid_payment_payload(
-        instrument_id="instr_fail"
+      instrument_id="instr_fail"
     )
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=payment_payload,
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=payment_payload,
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 402)
@@ -191,16 +193,16 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
     payment_payload = integration_test_utils.get_valid_payment_payload()
 
     response = self.client.post(
-        f"/checkout-sessions/{checkout_id}/complete",
-        json=payment_payload,
-        headers=integration_test_utils.get_headers(),
+      f"/checkout-sessions/{checkout_id}/complete",
+      json=payment_payload,
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 400)
     self.assertIn(
-        "Fulfillment address and option must be selected",
-        response.text,
-        msg="Expected error message for missing fulfillment",
+      "Fulfillment address and option must be selected",
+      response.text,
+      msg="Expected error message for missing fulfillment",
     )
 
   def test_structured_error_messages(self) -> None:
@@ -213,20 +215,20 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
     """
     # Get out of stock item from config
     out_of_stock_item = self.conformance_config.get(
-        "out_of_stock_item",
-        {"id": "out_of_stock_item_1", "title": "Out of Stock Item"},
+      "out_of_stock_item",
+      {"id": "out_of_stock_item_1", "title": "Out of Stock Item"},
     )
 
     create_payload = self.create_checkout_payload(
-        item_id=out_of_stock_item["id"],
+      item_id=out_of_stock_item["id"],
     )
 
     response = self.client.post(
-        "/checkout-sessions",
-        json=create_payload.model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        ),
-        headers=integration_test_utils.get_headers(),
+      "/checkout-sessions",
+      json=create_payload.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+      ),
+      headers=integration_test_utils.get_headers(),
     )
 
     self.assert_response_status(response, 400)

--- a/webhook_test.py
+++ b/webhook_test.py
@@ -18,11 +18,13 @@ import time
 from absl.testing import absltest
 import integration_test_utils
 from ucp_sdk.models.schemas.shopping import fulfillment_resp
-from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as Payment
+from ucp_sdk.models.schemas.shopping.payment_resp import (
+  PaymentResponse as Payment,
+)
 
 # Rebuild models to resolve forward references
 fulfillment_resp.Checkout.model_rebuild(
-    _types_namespace={"PaymentResponse": Payment}
+  _types_namespace={"PaymentResponse": Payment}
 )
 
 
@@ -30,15 +32,17 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
   """Tests for Webhook notifications."""
 
   def setUp(self) -> None:
+    """Set up the webhook server and configuration."""
     super().setUp()
     port = integration_test_utils.FLAGS.mock_webhook_port
     self.webhook_server = integration_test_utils.MockWebhookServer(port=port)
     self.webhook_server.start()
     self.webhook_url = (
-        f"http://localhost:{port}/webhooks/partners/test_partner/events/order"
+      f"http://localhost:{port}/webhooks/partners/test_partner/events/order"
     )
 
   def tearDown(self) -> None:
+    """Stop the webhook server and clean up."""
     self.webhook_server.stop()
     super().tearDown()
 
@@ -64,11 +68,11 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
     # 3. Trigger Shipping
     headers = self.get_headers()
     headers["Simulation-Secret"] = (
-        integration_test_utils.FLAGS.simulation_secret
+      integration_test_utils.FLAGS.simulation_secret
     )
     ship_response = self.client.post(
-        f"/testing/simulate-shipping/{order_id}",
-        headers=headers,
+      f"/testing/simulate-shipping/{order_id}",
+      headers=headers,
     )
     self.assert_response_status(ship_response, 200)
 
@@ -81,15 +85,15 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
 
     events = self.webhook_server.events
     self.assertGreaterEqual(
-        len(events),
-        2,
-        f"Expected at least 2 events, got {len(events)}",
+      len(events),
+      2,
+      f"Expected at least 2 events, got {len(events)}",
     )
 
     # Verify order_placed event
     placed_event = next(
-        (e for e in events if e["payload"]["event_type"] == "order_placed"),
-        None,
+      (e for e in events if e["payload"]["event_type"] == "order_placed"),
+      None,
     )
     self.assertIsNotNone(placed_event, "Missing order_placed event")
     self.assertEqual(placed_event["payload"]["checkout_id"], checkout_id)
@@ -97,19 +101,19 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
 
     # Verify order_shipped event
     shipped_event = next(
-        (e for e in events if e["payload"]["event_type"] == "order_shipped"),
-        None,
+      (e for e in events if e["payload"]["event_type"] == "order_shipped"),
+      None,
     )
     self.assertIsNotNone(shipped_event, "Missing order_shipped event")
     self.assertEqual(shipped_event["payload"]["checkout_id"], checkout_id)
     self.assertEqual(shipped_event["payload"]["order"]["id"], order_id)
 
     fulfillment_events = shipped_event["payload"]["order"]["fulfillment"].get(
-        "events", []
+      "events", []
     )
     self.assertTrue(
-        any(e["type"] == "shipped" for e in fulfillment_events),
-        "order_shipped event did not contain shipment info in order data",
+      any(e["type"] == "shipped" for e in fulfillment_events),
+      "order_shipped event did not contain shipment info in order data",
     )
 
   def test_webhook_order_address_known_customer(self) -> None:
@@ -120,50 +124,50 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
 
     # Trigger fulfillment update to inject address
     self.update_checkout_session(
-        checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
+      checkout_obj, fulfillment={"methods": [{"type": "shipping"}]}
     )
 
     # Fetch to get injected destinations
     response = self.client.get(
-        f"/checkout-sessions/{checkout_obj.id}", headers=self.get_headers()
+      f"/checkout-sessions/{checkout_obj.id}", headers=self.get_headers()
     )
     checkout_data = response.json()
     checkout_obj = fulfillment_resp.Checkout(**checkout_data)
 
     if (
-        checkout_obj.fulfillment
-        and checkout_obj.fulfillment.root.methods
-        and checkout_obj.fulfillment.root.methods[0].destinations
+      checkout_obj.fulfillment
+      and checkout_obj.fulfillment.root.methods
+      and checkout_obj.fulfillment.root.methods[0].destinations
     ):
       method = checkout_obj.fulfillment.root.methods[0]
       dest_id = method.destinations[0].root.id
       # Select destination first to calculate options
       self.update_checkout_session(
-          checkout_obj,
-          fulfillment={
-              "methods": [
-                  {"type": "shipping", "selected_destination_id": dest_id}
-              ]
-          },
+        checkout_obj,
+        fulfillment={
+          "methods": [{"type": "shipping", "selected_destination_id": dest_id}]
+        },
       )
 
       # Fetch again to get options
       response = self.client.get(
-          f"/checkout-sessions/{checkout_obj.id}", headers=self.get_headers()
+        f"/checkout-sessions/{checkout_obj.id}", headers=self.get_headers()
       )
       checkout_obj = fulfillment_resp.Checkout(**response.json())
       method = checkout_obj.fulfillment.root.methods[0]
       if method.groups and method.groups[0].options:
         option_id = method.groups[0].options[0].id
         self.update_checkout_session(
-            checkout_obj,
-            fulfillment={
-                "methods": [{
-                    "type": "shipping",
-                    "selected_destination_id": dest_id,
-                    "groups": [{"selected_option_id": option_id}],
-                }]
-            },
+          checkout_obj,
+          fulfillment={
+            "methods": [
+              {
+                "type": "shipping",
+                "selected_destination_id": dest_id,
+                "groups": [{"selected_option_id": option_id}],
+              }
+            ]
+          },
         )
 
     complete_response = self.complete_checkout_session(checkout_obj.id)
@@ -175,12 +179,12 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
       time.sleep(0.1)
 
     event = next(
-        (
-            e
-            for e in self.webhook_server.events
-            if e["payload"]["order"]["id"] == order_id
-        ),
-        None,
+      (
+        e
+        for e in self.webhook_server.events
+        if e["payload"]["order"]["id"] == order_id
+      ),
+      None,
     )
     self.assertIsNotNone(event)
     expectations = event["payload"]["order"]["fulfillment"]["expectations"]
@@ -194,24 +198,26 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
     checkout_obj = fulfillment_resp.Checkout(**checkout_data)
 
     new_address = {
-        "id": "dest_new_webhook",
-        "address_country": "CA",
-        "postal_code": "M5V 2H1",
-        "street_address": "Webhook St",
+      "id": "dest_new_webhook",
+      "address_country": "CA",
+      "postal_code": "M5V 2H1",
+      "street_address": "Webhook St",
     }
     # Send address to get options
     fulfillment_payload = {
-        "methods": [{
-            "type": "shipping",
-            "destinations": [new_address],
-            "selected_destination_id": "dest_new_webhook",
-        }]
+      "methods": [
+        {
+          "type": "shipping",
+          "destinations": [new_address],
+          "selected_destination_id": "dest_new_webhook",
+        }
+      ]
     }
     self.update_checkout_session(checkout_obj, fulfillment=fulfillment_payload)
 
     # Fetch to get options
     response = self.client.get(
-        f"/checkout-sessions/{checkout_obj.id}", headers=self.get_headers()
+      f"/checkout-sessions/{checkout_obj.id}", headers=self.get_headers()
     )
     checkout_obj = fulfillment_resp.Checkout(**response.json())
     method = checkout_obj.fulfillment.root.methods[0]
@@ -220,11 +226,11 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
       option_id = method.groups[0].options[0].id
       # Select option
       fulfillment_payload["methods"][0]["groups"] = [
-          {"selected_option_id": option_id}
+        {"selected_option_id": option_id}
       ]
       fulfillment_payload["methods"][0]["type"] = "shipping"
       self.update_checkout_session(
-          checkout_obj, fulfillment=fulfillment_payload
+        checkout_obj, fulfillment=fulfillment_payload
       )
 
     complete_response = self.complete_checkout_session(checkout_obj.id)
@@ -236,19 +242,19 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
       time.sleep(0.1)
 
     event = next(
-        (
-            e
-            for e in self.webhook_server.events
-            if e["payload"]["order"]["id"] == order_id
-        ),
-        None,
+      (
+        e
+        for e in self.webhook_server.events
+        if e["payload"]["order"]["id"] == order_id
+      ),
+      None,
     )
     self.assertIsNotNone(event)
     expectations = event["payload"]["order"]["fulfillment"]["expectations"]
     self.assertTrue(expectations)
     self.assertEqual(expectations[0]["destination"]["address_country"], "CA")
     self.assertEqual(
-        expectations[0]["destination"]["street_address"], "Webhook St"
+      expectations[0]["destination"]["street_address"], "Webhook St"
     )
 
 


### PR DESCRIPTION
- Add `ruff` to `pyproject.toml` with configuration for line length and style.
- Reformat all Python test files to comply with the 2-space indentation style.
- Update `pathlib` usage over `os.path` for better path handling in tests.
- Refactor imports to resolve forward reference issues in Pydantic models.
- Standardize multi-line function calls and dictionary literals for readability.
- Fix various linting issues including unused variables and broad exception handling.