### PR TITLE
Update UCP conformance tests to use discovered service endpoints.

### DIFF
--- a/protocol_test.py
+++ b/protocol_test.py
@@ -91,6 +91,13 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     self.assertEqual(shop_pay.name, "com.shopify.shop_pay")
     self.assertIn("shop_id", shop_pay.config)
 
+    # Verify shopping capability
+    self.assertIn("dev.ucp.shopping", profile.ucp.services.root)
+    shopping_service = profile.ucp.services.root["dev.ucp.shopping"]
+    self.assertEqual(shopping_service.version.root, "2026-01-11")
+    self.assertIsNotNone(shopping_service.rest)
+    self.assertIsNotNone(shopping_service.rest.endpoint)
+
   def test_version_negotiation(self):
     """Test protocol version negotiation via headers.
 
@@ -100,6 +107,25 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     When the request includes a 'UCP-Agent' header with an incompatible version,
     then the request fails with 400 Bad Request.
     """
+    # Discover shopping service endpoint
+    discovery_resp = self.client.get("/.well-known/ucp")
+    self.assert_response_status(discovery_resp, 200)
+    profile = UcpDiscoveryProfile(**discovery_resp.json())
+    shopping_service = profile.ucp.services.root["dev.ucp.shopping"]
+    self.assertIsNotNone(
+        shopping_service, "Shopping service not found in discovery"
+    )
+    self.assertIsNotNone(
+        shopping_service.rest, "REST config not found for shopping service"
+    )
+    self.assertIsNotNone(
+        shopping_service.rest.endpoint,
+        "Endpoint not found for shopping service",
+    )
+    checkout_sessions_url = (
+        f"{str(shopping_service.rest.endpoint).rstrip('/')}/checkout-sessions"
+    )
+
     create_payload = self.create_checkout_payload()
 
     # 1. Compatible Version


### PR DESCRIPTION
The discovery test now verifies the presence of the "dev.ucp.shopping" service. The version negotiation test now dynamically fetches the shopping service endpoint from the UCP discovery profile before making requests to /checkout-sessions.

No changes needed for the python sample.