### PR TITLE
fix: update the protocol test to match advertisement

### DIFF
--- a/protocol_test.py
+++ b/protocol_test.py
@@ -60,9 +60,6 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     expected_capabilities = {
       "dev.ucp.shopping.checkout",
       "dev.ucp.shopping.order",
-      "dev.ucp.shopping.refund",
-      "dev.ucp.shopping.return",
-      "dev.ucp.shopping.dispute",
       "dev.ucp.shopping.discount",
       "dev.ucp.shopping.fulfillment",
       "dev.ucp.shopping.buyer_consent",


### PR DESCRIPTION
[https://github.com/Universal-Commerce-Protocol/samples/pull/10] updated the advertised extension definitions to remove some obsolete items; update the protocol test to match the current definitions.