### PR TITLE
fix: Update fulfilment test to treat [] and None equally.

### DIFF
--- a/fulfillment_test.py
+++ b/fulfillment_test.py
@@ -213,7 +213,9 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
 
     # Verify no destinations injected
     method = updated_checkout.fulfillment.root.methods[0]
-    self.assertIsNone(method.destinations)
+    self.assertTrue(
+      method.destinations is None or len(method.destinations) == 0
+    )
 
   def test_known_customer_no_address(self) -> None:
     """Test that a known customer with no stored address gets no injection."""
@@ -230,7 +232,9 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     updated_checkout = checkout.Checkout(**response_json)
 
     method = updated_checkout.fulfillment.root.methods[0]
-    self.assertIsNone(method.destinations)
+    self.assertTrue(
+      method.destinations is None or len(method.destinations) == 0
+    )
 
   def test_known_customer_one_address(self) -> None:
     """Test that a known customer with an address gets it injected."""

--- a/fulfillment_test.py
+++ b/fulfillment_test.py
@@ -254,7 +254,8 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
 
     # Verify no destinations injected
     method = updated_checkout.model_extra["fulfillment"]["methods"][0]
-    self.assertIsNone(method.get("destinations"))
+    destinations = method.get("destinations")
+    self.assertTrue(destinations is None or len(destinations) == 0)
 
   def test_known_customer_no_address(self) -> None:
     """Test that a known customer with no stored address gets no injection."""
@@ -280,7 +281,8 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     updated_checkout = checkout.Checkout(**response_json)
 
     method = updated_checkout.model_extra["fulfillment"]["methods"][0]
-    self.assertIsNone(method.get("destinations"))
+    destinations = method.get("destinations")
+    self.assertTrue(destinations is None or len(destinations) == 0)
 
   def test_known_customer_one_address(self) -> None:
     """Test that a known customer with an address gets it injected."""


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing
      functionality to not work as expected, **including removal of schema files
      or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

If you checked "Breaking change" above, or if you are removing **any** schema
files or fields:

- [ ] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [ ] **I have added justification below.**

## Breaking Changes / Removal Justification

(Please provide a detailed technical and strategic rationale here for why this
breaking change or removal is necessary.)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

From business logic perspective empty list and none are equivalent, the test is too strict.