### PR TITLE
ci: add conformance test workflow

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -1,0 +1,113 @@
+# Copyright 2026 UCP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Conformance Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Nightly at 2:17 AM UTC
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  MERCHANT_SERVER_PORT: 8182
+  SIMULATION_SECRET: super-secret-sim-key
+  DATABASE_PATH: /tmp/ucp_test
+
+jobs:
+  test:
+    name: Run Conformance Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out conformance repo
+        uses: actions/checkout@v4
+        with:
+          path: conformance
+
+      - name: Check out samples repo
+        uses: actions/checkout@v4
+        with:
+          repository: Universal-Commerce-Protocol/samples
+          path: samples
+
+      - name: Check out SDK repo
+        uses: actions/checkout@v4
+        with:
+          repository: Universal-Commerce-Protocol/sdk
+          path: sdk
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: |
+          uv sync --directory sdk/python/
+          uv sync --directory samples/rest/python/server/
+          uv sync --directory conformance/
+
+      - name: Initialize test database
+        run: |
+          rm -rf ${DATABASE_PATH}
+          mkdir -p ${DATABASE_PATH}
+          uv run --directory samples/rest/python/server import_csv.py \
+            --products_db_path=${DATABASE_PATH}/products.db \
+            --transactions_db_path=${DATABASE_PATH}/transactions.db \
+            --data_dir=../../../../conformance/test_data/flower_shop
+
+      - name: Start Flower Shop server
+        run: |
+          uv run --directory samples/rest/python/server server.py \
+            --products_db_path=${DATABASE_PATH}/products.db \
+            --transactions_db_path=${DATABASE_PATH}/transactions.db \
+            --port=${MERCHANT_SERVER_PORT} \
+            --simulation_secret=${SIMULATION_SECRET} &
+          # Wait for the server to be ready
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:${MERCHANT_SERVER_PORT}/.well-known/ucp > /dev/null 2>&1; then
+              echo "Server is ready"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Server failed to start within 30 seconds"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run conformance tests
+        continue-on-error: true
+        working-directory: conformance
+        run: |
+          EXIT_CODE=0
+          for test_file in *_test.py; do
+            echo "::group::${test_file}"
+            if ! uv run "${test_file}" \
+              --server_url=http://localhost:${MERCHANT_SERVER_PORT} \
+              --simulation_secret=${SIMULATION_SECRET} \
+              --conformance_input=test_data/flower_shop/conformance_input.json; then
+              EXIT_CODE=1
+            fi
+            echo "::endgroup::"
+          done
+          exit ${EXIT_CODE}

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Check out SDK repo
         uses: actions/checkout@v4
         with:
-          repository: Universal-Commerce-Protocol/sdk
-          path: sdk
+          repository: Universal-Commerce-Protocol/python-sdk
+          path: python-sdk
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -62,7 +62,7 @@ jobs:
 
       - name: Sync dependencies
         run: |
-          uv sync --directory sdk/python/
+          uv sync --directory python-sdk/
           uv sync --directory samples/rest/python/server/
           uv sync --directory conformance/
 
@@ -96,7 +96,7 @@ jobs:
           done
 
       - name: Run conformance tests
-        continue-on-error: true
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         working-directory: conformance
         run: |
           EXIT_CODE=0

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          prune-cache: false
 
       - name: Set up Python
         run: uv python install 3.12


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs the full conformance test suite
- Checks out conformance, samples, and SDK repos in correct relative paths
- Starts the Flower Shop reference server with test data
- Runs all `*_test.py` files and reports per-file results using GitHub log groups
- Triggers on: PRs to main, pushes to main, nightly schedule, manual dispatch
- Results are informational (`continue-on-error`) - does not block merges

This would have caught the breakage from #28 before merge (see #37).

Addresses #38

## Test plan
- [x] Verify workflow runs on this PR
- [x] Confirm server health check wait loop works
- [x] Confirm all test files are discovered and executed