### PR TITLE
fix: support ucp envelope in discovery profile tests

### DIFF
--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -392,8 +392,10 @@ class IntegrationTestBase(absltest.TestCase):
       self.assert_response_status(discovery_resp, 200)
 
       profile_data = discovery_resp.json()
+      # Unwrap "ucp" envelope if present (both 01-23 and 04-08 nest under "ucp")
+      ucp_data = profile_data.get("ucp", profile_data)
       # UCP 01-23 validation changed dicts to lists
-      shopping_services = profile_data.get("services", {}).get(
+      shopping_services = ucp_data.get("services", {}).get(
         "dev.ucp.shopping", []
       )
       if not shopping_services:

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -101,7 +101,9 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     """
     response = self.client.get("/.well-known/ucp")
     self.assert_response_status(response, 200)
-    profile = response.json()
+    raw_profile = response.json()
+    # Unwrap "ucp" envelope if present
+    profile = raw_profile.get("ucp", raw_profile)
 
     url_entries = self._extract_document_urls(profile)
     failures = []
@@ -154,7 +156,9 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     """
     response = self.client.get("/.well-known/ucp")
     self.assert_response_status(response, 200)
-    data = response.json()
+    raw_data = response.json()
+    # Unwrap "ucp" envelope if present (spec nests under "ucp" key)
+    data = raw_data.get("ucp", raw_data)
 
     # Validate schema using SDK model
     BusinessSchema(**data)
@@ -232,7 +236,9 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     discovery_resp = self.client.get("/.well-known/ucp")
     self.assert_response_status(discovery_resp, 200)
     profile_dict = discovery_resp.json()
-    shopping_services = profile_dict.get("services", {}).get("dev.ucp.shopping")
+    # Unwrap "ucp" envelope if present
+    ucp_dict = profile_dict.get("ucp", profile_dict)
+    shopping_services = ucp_dict.get("services", {}).get("dev.ucp.shopping")
     self.assertIsNotNone(
       shopping_services, "Shopping service not found in discovery"
     )


### PR DESCRIPTION
# Description

The UCP specification (2026-01-23 / 2026-04-08) wraps the `.well-known/ucp` discovery response under a top-level `"ucp"` key. The current test code assumes `services` is always at the top level of the JSON response, which causes test failures against compliant server implementations that use the envelope format.

This PR adds backward-compatible envelope unwrapping:

- If the response contains a `"ucp"` key, it is used as the root for field access.
- If not, the original top-level object is used (maintaining backward compatibility).

### Files changed

- **`integration_test_utils.py`**: Updated discovery profile parsing to unwrap the `ucp` envelope before extracting shopping service endpoints.
- **`protocol_test.py`**: Updated all discovery-related tests to unwrap the `ucp` envelope when validating profile structure, service bindings, and version negotiation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes