### PR TITLE
feat: update conformance suite for UCP 2026-04-08

### DIFF
--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -45,17 +45,58 @@ from ucp_sdk.models.schemas.shopping.types import (
 from ucp_sdk.models.schemas.shopping.types import (
   fulfillment_method_create_request,
 )
+from ucp_sdk.models.schemas.shopping.types.amount import Amount
 from ucp_sdk.models.schemas.shopping.types import item_create_request
 from ucp_sdk.models.schemas.shopping.types import item_update_request
 from ucp_sdk.models.schemas.shopping.types import line_item_create_request
 from ucp_sdk.models.schemas.shopping.types import line_item_update_request
+from ucp_sdk.models.schemas.shopping.types.signed_amount import SignedAmount
 from ucp_sdk.models.schemas import payment_handler
 from ucp_sdk.models.schemas.shopping.types import shipping_destination
+from ucp_sdk.models.schemas.shopping.types.totals import Totals
+
+UCP_VERSION = "2026-04-08"
 import uvicorn
 
 
 class UnifiedUpdate(CheckoutUpdateRequest):
   """Client-side unified update model to support extensions."""
+
+
+def _patch_sdk_root_models() -> None:
+  """Make generated April SDK root models test-friendly.
+
+  The April 2026 Python SDK models introduce RootModel wrappers for scalar
+  amounts and for checkout/order totals. These wrappers are correct at the
+  schema layer, but direct iteration/comparison is awkward in the existing
+  conformance assertions.
+  """
+
+  def _scalar_eq(self: Any, other: Any) -> bool:
+    if hasattr(other, "root"):
+      return self.root == other.root
+    return self.root == other
+
+  def _scalar_int(self: Any) -> int:
+    return int(self.root)
+
+  def _scalar_str(self: Any) -> str:
+    return str(self.root)
+
+  Amount.__eq__ = _scalar_eq
+  Amount.__int__ = _scalar_int
+  Amount.__index__ = _scalar_int
+  Amount.__str__ = _scalar_str
+
+  SignedAmount.__eq__ = _scalar_eq
+  SignedAmount.__int__ = _scalar_int
+  SignedAmount.__index__ = _scalar_int
+  SignedAmount.__str__ = _scalar_str
+
+  Totals.__iter__ = lambda self: iter(self.root)
+
+
+_patch_sdk_root_models()
 
 
 FLAGS = flags.FLAGS
@@ -480,7 +521,7 @@ class IntegrationTestBase(absltest.TestCase):
         payment_handler.PaymentHandler(
           id="google_pay",
           name="google.pay",
-          version="2026-01-23",
+          version=UCP_VERSION,
           spec="https://example.com/spec",
           config_schema="https://example.com/schema",
           instrument_schemas=["https://example.com/instrument_schema"],
@@ -540,7 +581,7 @@ class IntegrationTestBase(absltest.TestCase):
       fulfillment=fulfillment,
     )
     checkout_req.status = "incomplete"
-    checkout_req.ucp = {"version": "2026-01-23"}
+    checkout_req.ucp = {"version": UCP_VERSION}
     checkout_req.totals = []
     checkout_req.links = []
 

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -18,14 +18,19 @@ from absl.testing import absltest
 import integration_test_utils
 import httpx
 from pydantic import ValidationError
-from ucp_sdk.models.schemas.ucp import BusinessSchema, ReverseDomainName
+from ucp_sdk.models.schemas.ucp import BusinessSchema
 from ucp_sdk.models.schemas.shopping import checkout as checkout
 from ucp_sdk.models.schemas.shopping.payment import (
   Payment,
 )
+from ucp_sdk.models.schemas.shopping.types.reverse_domain_name import (
+  ReverseDomainName,
+)
 
 # Rebuild models to resolve forward references
 checkout.Checkout.model_rebuild(_types_namespace={"Payment": Payment})
+
+UCP_VERSION = "2026-04-08"
 
 
 class ProtocolTest(integration_test_utils.IntegrationTestBase):
@@ -162,7 +167,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
 
     self.assertEqual(
       data.get("version"),
-      "2026-01-23",
+      UCP_VERSION,
       msg="Unexpected UCP version in discovery doc",
     )
 
@@ -223,7 +228,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
       if isinstance(shopping_services, list)
       else shopping_services
     )
-    self.assertEqual(shopping_service.get("version"), "2026-01-23")
+    self.assertEqual(shopping_service.get("version"), UCP_VERSION)
     self.assertIsNotNone(shopping_service.get("transport") == "rest")
     self.assertIsNotNone(shopping_service.get("endpoint"))
 
@@ -265,7 +270,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
 
     # 1. Compatible Version
     headers = integration_test_utils.get_headers()
-    headers["UCP-Agent"] = 'profile="..."; version="2026-01-23"'
+    headers["UCP-Agent"] = f'profile="..."; version="{UCP_VERSION}"'
     response = self.client.post(
       checkout_sessions_url,
       json=create_payload.model_dump(

--- a/shopping-agent-test.json
+++ b/shopping-agent-test.json
@@ -1,13 +1,13 @@
 {
   "ucp": {
-    "version": "2026-01-23",
+    "version": "2026-04-08",
     "capabilities": {
       "dev.ucp.shopping.order": [
         {
           "name": "dev.ucp.shopping.order",
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/order/",
-          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/order.json",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/order/",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/order.json",
           "config": {
             "webhook_url": "http://localhost:{webhook_port}/webhooks/partners/test_partner/events/order"
           }


### PR DESCRIPTION
## Summary

Updates `conformance` to the official UCP `2026-04-08` release.

Dependency chain for April validation:
- `Universal-Commerce-Protocol/python-sdk#28`
- `Universal-Commerce-Protocol/samples#91`
- this PR

This PR removes stale `2026-01-23` protocol expectations from the suite, updates official `ucp.dev` spec/schema references to April, and adapts the tests to the April Python SDK model layout where the existing suite assumed January-era imports and scalar wrappers.

## Changes

- update hard-coded UCP version expectations from `2026-01-23` to `2026-04-08`
- update official spec/schema URLs to `https://ucp.dev/2026-04-08/...`
- update `ReverseDomainName` imports for the April Python SDK layout
- make conformance assertions compatible with April SDK RootModel wrappers used for `Amount`, `SignedAmount`, and `Totals`
- update the shopping agent profile fixture to advertise April capability metadata

## Why

The official latest UCP spec release is `2026-04-08`, but `conformance` still contains January-era protocol pins and SDK assumptions. That causes the suite to drift from the current published spec and from the April Python SDK update.

This PR keeps the scope limited to conformance-suite April alignment. Merchant-server fixes remain in `samples#91`, and SDK model updates remain in `python-sdk#28`.

## Validation

Validated against:
- official spec overview: `https://ucp.dev/latest/specification/overview/`
- official April snapshot: `https://ucp.dev/2026-04-08/specification/overview/`
- `python-sdk#28`
- `samples#91`
- this branch

Serial test run result against the local April validation target:
- `protocol_test.py` OK
- `validation_test.py` OK
- `fulfillment_test.py` OK
- `business_logic_test.py` OK
- `checkout_lifecycle_test.py` OK
- `idempotency_test.py` OK
- `order_test.py` OK
- `webhook_test.py` OK
- `simulation_url_security_test.py` OK
- `ap2_test.py` OK
- `binding_test.py` OK
- `card_credential_test.py` OK

`test_discovery_urls` remains skipped because the remote schema publication check is not yet live on `ucp.dev`.

## Scope

Included here:
- conformance version/spec/schema alignment
- test-harness compatibility with April SDK model shapes

Explicitly not included here:
- merchant-server implementation fixes in `samples`
- SDK generator or model-shape changes in `python-sdk`