### PR TITLE
[codex] fix order endpoint resolution

### DIFF
--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -432,6 +432,10 @@ class IntegrationTestBase(absltest.TestCase):
     path = path.lstrip("/")
     return f"{base}/{path}"
 
+  def get_order_url(self, order_id: str) -> str:
+    """Construct a full URL for an order resource."""
+    return self.get_shopping_url(f"/orders/{order_id}")
+
   def tearDown(self) -> None:
     """Tear down the test case, stopping servers and clients."""
     self.client.close()

--- a/order_test.py
+++ b/order_test.py
@@ -57,7 +57,7 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order
     response = self.client.get(
-      f"/orders/{order_id}", headers=self.get_headers()
+      self.get_order_url(order_id), headers=self.get_headers()
     )
     self.assert_response_status(response, 200)
 
@@ -167,7 +167,7 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order and verify fulfillment details
     response = self.client.get(
-      f"/orders/{order_id}", headers=self.get_headers()
+      self.get_order_url(order_id), headers=self.get_headers()
     )
     self.assert_response_status(response, 200)
     order_obj = order.Order(**response.json())
@@ -274,7 +274,9 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     order_id = complete_data["order"]["id"]
 
     # Get Order
-    resp = self.client.get(f"/orders/{order_id}", headers=self.get_headers())
+    resp = self.client.get(
+      self.get_order_url(order_id), headers=self.get_headers()
+    )
     self.assert_response_status(resp, 200)
     order_obj = order.Order(**resp.json())
 
@@ -297,7 +299,7 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     order_obj.fulfillment.events.append(new_event)
 
     resp = self.client.put(
-      f"/orders/{order_id}",
+      self.get_order_url(order_id),
       json=order_obj.model_dump(mode="json", by_alias=True, exclude_none=True),
       headers=self.get_headers(),
     )
@@ -321,7 +323,9 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     order_id = self.create_completed_order()
 
     # Get Order
-    resp = self.client.get(f"/orders/{order_id}", headers=self.get_headers())
+    resp = self.client.get(
+      self.get_order_url(order_id), headers=self.get_headers()
+    )
     self.assert_response_status(resp, 200)
     order_obj = order.Order(**resp.json())
 
@@ -341,7 +345,7 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
 
     # Update Order
     resp = self.client.put(
-      f"/orders/{order_id}",
+      self.get_order_url(order_id),
       json=order_obj.model_dump(mode="json", by_alias=True, exclude_none=True),
       headers=self.get_headers(),
     )


### PR DESCRIPTION
## Summary

Fixes #42.

Order conformance tests now resolve `/orders/{id}` through the discovered UCP shopping service endpoint instead of calling the test server base URL directly.

## What changed

- Added `IntegrationTestBase.get_order_url(order_id)` as the order-resource equivalent of `get_shopping_url(...)`.
- Updated `order_test.py` GET and PUT calls for `/orders/{id}` to use the discovered shopping service endpoint.

## Why

The shopping REST spec says operation paths are relative to the merchant-provided endpoint from `/.well-known/ucp` under `services["dev.ucp.shopping"][transport=rest].endpoint`. Checkout tests already follow this pattern through `get_shopping_url(...)`, but order tests were still using the root `server_url`, which fails for implementations that mount the shopping service below a path prefix.

## Validation

- `uv run ruff format --check integration_test_utils.py order_test.py`
- `uv run ruff check integration_test_utils.py order_test.py`
- `uv run python -m py_compile integration_test_utils.py order_test.py`
- Smoke-checked `get_order_url(...)` with discovered endpoints both with and without a trailing slash.

I also attempted to run `order_test.py` against the local Flower Shop sample server. The server failed to start before conformance tests ran due to an existing local samples/python-sdk import mismatch: `ImportError: cannot import name 'Checkout' from 'ucp_sdk.models.schemas.shopping.ap2_mandate`.
