### PR TITLE
fix(ci): pin samples and python-sdk checkouts to last verified-green combination

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -47,12 +47,20 @@ jobs:
         with:
           repository: Universal-Commerce-Protocol/samples
           path: samples
+          # Pinned to the combination last verified green by the nightly run
+          # on 2026-06-30 (run 28418270435). Bump deliberately after
+          # validating a newer combination.
+          ref: 74e66deedc8270482f198a76c5ed1e6ff270814e
 
       - name: Check out SDK repo
         uses: actions/checkout@v5
         with:
           repository: Universal-Commerce-Protocol/python-sdk
           path: python-sdk
+          # See pin note above (samples). python-sdk@main moved past this on
+          # 2026-06-30 (#48) and the flower-shop server no longer boots,
+          # which is why the nightly has been red since 2026-07-01.
+          ref: f54858e0cf1e8933cc0e9d89b380e2cd4a0b3f00
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0


### PR DESCRIPTION
The nightly conformance run has been red since 2026-07-01 (e.g. run 28839412863; last green was 2026-06-30, run 28418270435). Root cause: the workflow checks out `samples@main` and `python-sdk@main` unpinned, so any incompatible move in either repo breaks this repo's signal with no change here.

That is exactly what happened: exactly one commit landed in either checked-out repo between the last green nightly and the first red one — python-sdk 298c295 (#48, 2026-06-30). After it, the Flower Shop server no longer boots (`ImportError: cannot import name 'Checkout' from 'ucp_sdk...ap2_mandate'`), so every test file fails at "Start Flower Shop server". Same root cause as Universal-Commerce-Protocol/samples#118, where the unpinned editable path dependency breaks the documented human setup path.

This PR pins both checkouts to the combination the last green nightly actually ran (samples `74e66de`, python-sdk `f54858e`), with comments documenting the provenance and the bump procedure.

**Verification**
- Local: full suite against the pinned combination — all 13 test files pass (exit 0).
- Local negative control: same layout with python-sdk@main — the server fails to boot with the ImportError above (the current nightly failure).
- CI: the identical diff running in my fork is green end-to-end: https://github.com/vishkaty/conformance/actions/runs/28897597473

**Notes**
- Deliberately minimal: restores the nightly signal today and deletes cleanly whenever the suite restructure mentioned in #41 lands.
- If you'd rather keep `samples` tracking main and pin only `python-sdk`, happy to adjust — pinned-both is simply the exactly-reproduced green state.
- Possible follow-up (separate PR if useful): a second `continue-on-error` nightly job against both @main as an early-warning drift canary.