### PR TITLE
fix!: adapt to updated python sdk

### DIFF
--- a/business_logic_test.py
+++ b/business_logic_test.py
@@ -68,10 +68,10 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
     # Verify Line Item Calculations
     line_item = checkout_obj.line_items[0]
     li_subtotal = next(
-      (t.amount for t in line_item.totals if t.type == "subtotal"), 0
+      (t.amount.root for t in line_item.totals if t.type == "subtotal"), 0
     )
     li_total = next(
-      (t.amount for t in line_item.totals if t.type == "total"), 0
+      (t.amount.root for t in line_item.totals if t.type == "total"), 0
     )
 
     self.assertEqual(
@@ -87,22 +87,22 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
 
     # Verify Totals Breakdown
     subtotal = next(
-      (t for t in checkout_obj.totals if t.type == "subtotal"), None
+      (t for t in checkout_obj.totals.root if t.type == "subtotal"), None
     )
     total_obj = next(
-      (t for t in checkout_obj.totals if t.type == "total"), None
+      (t for t in checkout_obj.totals.root if t.type == "total"), None
     )
 
     self.assertIsNotNone(subtotal, "Subtotal missing")
     self.assertEqual(
-      subtotal.amount,
+      subtotal.amount.root,
       expected_price,
       f"Subtotal amount should match DB price {expected_price}",
     )
 
     self.assertIsNotNone(total_obj, "Total missing")
     self.assertEqual(
-      total_obj.amount,
+      total_obj.amount.root,
       expected_price,
       f"Total amount should match DB price {expected_price}",
     )
@@ -158,15 +158,15 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
 
     updated_checkout = checkout.Checkout(**response.json())
     total_obj = next(
-      (t for t in updated_checkout.totals if t.type == "total"), None
+      (t for t in updated_checkout.totals.root if t.type == "total"), None
     )
     expected_total = expected_price * 2
     self.assertEqual(
-      total_obj.amount,
+      total_obj.amount.root,
       expected_total,
       msg=(
         "Server did not correct totals on update. Expected"
-        f" {expected_total}, got {total_obj.amount}"
+        f" {expected_total}, got {total_obj.amount.root}"
       ),
     )
 
@@ -226,15 +226,15 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
     expected_total = int(expected_price * 0.9)
 
     total_obj = next(
-      (t for t in discounted_checkout.totals if t.type == "total"), None
+      (t for t in discounted_checkout.totals.root if t.type == "total"), None
     )
     self.assertIsNotNone(total_obj, "Total object missing")
     self.assertEqual(
-      total_obj.amount,
+      total_obj.amount.root,
       expected_total,
       msg=(
         f"Discount not applied correctly. Expected {expected_total}, got"
-        f" {total_obj.amount}"
+        f" {total_obj.amount.root}"
       ),
     )
 
@@ -284,13 +284,13 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
     expected_total = int(int(expected_price * 0.9) * 0.8)
 
     total_obj = next(
-      (t for t in discounted_checkout.totals if t.type == "total"), None
+      (t for t in discounted_checkout.totals.root if t.type == "total"), None
     )
     self.assertEqual(
-      total_obj.amount,
+      total_obj.amount.root,
       expected_total,
       f"Multiple discounts failed. Exp {expected_total}, "
-      f"got {total_obj.amount}",
+      f"got {total_obj.amount.root}",
     )
 
     # Verify both applied discounts are present
@@ -332,9 +332,9 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
     expected_total = int(expected_price * 0.9)
 
     total_obj = next(
-      (t for t in discounted_checkout.totals if t.type == "total"), None
+      (t for t in discounted_checkout.totals.root if t.type == "total"), None
     )
-    self.assertEqual(total_obj.amount, expected_total)
+    self.assertEqual(total_obj.amount.root, expected_total)
 
     # Verify only one applied discount is present
     discounts_data = getattr(discounted_checkout, "discounts", {})
@@ -373,14 +373,15 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
     expected_total = expected_price - 500
 
     total_obj = next(
-      (t for t in discounted_checkout.totals if t.type == "total"), None
+      (t for t in discounted_checkout.totals.root if t.type == "total"), None
     )
     self.assertIsNotNone(total_obj, "Total object missing")
     self.assertEqual(
-      total_obj.amount,
+      total_obj.amount.root,
       expected_total,
       msg=(
-        f"Fixed discount failed. Exp {expected_total}, got {total_obj.amount}"
+        f"Fixed discount failed. Exp {expected_total}, got"
+        f" {total_obj.amount.root}"
       ),
     )
 
@@ -399,7 +400,7 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
       "FIXED500",
     )
     self.assertEqual(
-      discounts_obj.applied[0].amount,
+      discounts_obj.applied[0].amount.root,
       500,
     )
 

--- a/fulfillment_test.py
+++ b/fulfillment_test.py
@@ -121,15 +121,15 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
 
     expected_total = 3500 + option_cost  # Base 3500 + shipping
     total_obj = next(
-      (t for t in final_checkout.totals if t.type == "total"), None
+      (t for t in final_checkout.totals.root if t.type == "total"), None
     )
     self.assertIsNotNone(total_obj, "Total object missing")
     self.assertEqual(
-      total_obj.amount,
+      total_obj.amount.root,
       expected_total,
       msg=(
         f"Total not updated correctly. Expected {expected_total}, got"
-        f" {total_obj.amount}"
+        f" {total_obj.amount.root}"
       ),
     )
 

--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -393,7 +393,7 @@ class IntegrationTestBase(absltest.TestCase):
 
       profile_data = discovery_resp.json()
       # UCP 01-23 validation changed dicts to lists
-      shopping_services = profile_data.get("services", {}).get(
+      shopping_services = profile_data.get("ucp", {}).get("services", {}).get(
         "dev.ucp.shopping", []
       )
       if not shopping_services:

--- a/invalid_input_test.py
+++ b/invalid_input_test.py
@@ -98,7 +98,7 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
     updated_checkout = checkout.Checkout(**resp_json)
     # Verify no discount applied
     discount_total = next(
-      (t for t in updated_checkout.totals if t.type == "discount"), None
+      (t for t in updated_checkout.totals.root if t.type == "discount"), None
     )
     self.assertIsNone(
       discount_total, "Unknown discount code should not apply discount"

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -18,7 +18,10 @@ from absl.testing import absltest
 import integration_test_utils
 import httpx
 from pydantic import ValidationError
-from ucp_sdk.models.schemas.ucp import BusinessSchema, ReverseDomainName
+from ucp_sdk.models.schemas.ucp import BusinessSchema
+from ucp_sdk.models.schemas.shopping.types.reverse_domain_name import (
+  ReverseDomainName,
+)
 from ucp_sdk.models.schemas.shopping import checkout as checkout
 from ucp_sdk.models.schemas.shopping.payment import (
   Payment,


### PR DESCRIPTION
<!--
   Copyright 2026 UCP Authors

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->

# Description
Adapt SDK usage to changes from https://github.com/Universal-Commerce-Protocol/python-sdk/pull/48
+ minor fix in extracting shopping services

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

---

### Is this a Breaking Change or Removal?
Yes
- [X] **I have added `!` to my PR title** (e.g., `feat!: remove field`).
- [X] **I have added justification below.**

## Breaking Changes / Removal Justification
Python SDK has been updated in a non backwards compatible way, this is a breaking change that adapts this repo to the SDK's breakin change.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules