### PR TITLE
fix: update conformance tests to expect UCP version 2026-04-08

### DIFF
--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -483,7 +483,7 @@ class IntegrationTestBase(absltest.TestCase):
         payment_handler.Base(
           id="google_pay",
           name="google.pay",
-          version="2026-01-23",
+          version="2026-04-08",
           spec="https://example.com/spec",
           config_schema="https://example.com/schema",
           instrument_schemas=["https://example.com/instrument_schema"],
@@ -541,7 +541,7 @@ class IntegrationTestBase(absltest.TestCase):
       fulfillment=fulfillment,
     )
     checkout_req.status = "incomplete"
-    checkout_req.ucp = {"version": "2026-01-23"}
+    checkout_req.ucp = {"version": "2026-04-08"}
     checkout_req.totals = []
     checkout_req.links = []
 

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -169,7 +169,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
 
     self.assertEqual(
       ucp_data.get("version"),
-      "2026-01-23",
+      "2026-04-08",
       msg="Unexpected UCP version in discovery doc",
     )
 
@@ -230,7 +230,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
       if isinstance(shopping_services, list)
       else shopping_services
     )
-    self.assertEqual(shopping_service.get("version"), "2026-01-23")
+    self.assertEqual(shopping_service.get("version"), "2026-04-08")
     self.assertIsNotNone(shopping_service.get("transport") == "rest")
     self.assertIsNotNone(shopping_service.get("endpoint"))
 
@@ -273,7 +273,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
 
     # 1. Compatible Version
     headers = integration_test_utils.get_headers()
-    headers["UCP-Agent"] = 'profile="..."; version="2026-01-23"'
+    headers["UCP-Agent"] = 'profile="..."; version="2026-04-08"'
     response = self.client.post(
       checkout_sessions_url,
       json=create_payload.model_dump(

--- a/shopping-agent-test.json
+++ b/shopping-agent-test.json
@@ -1,13 +1,13 @@
 {
   "ucp": {
-    "version": "2026-01-23",
+    "version": "2026-04-08",
     "capabilities": {
       "dev.ucp.shopping.order": [
         {
           "name": "dev.ucp.shopping.order",
-          "version": "2026-01-23",
-          "spec": "https://ucp.dev/2026-01-23/specification/order/",
-          "schema": "https://ucp.dev/2026-01-23/schemas/shopping/order.json",
+          "version": "2026-04-08",
+          "spec": "https://ucp.dev/2026-04-08/specification/order/",
+          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/order.json",
           "config": {
             "webhook_url": "http://localhost:{webhook_port}/webhooks/partners/test_partner/events/order"
           }


### PR DESCRIPTION
# Description

Update hardcoded version expectations in conformance tests to match the updated server version 2026-04-08.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

<!-- Link to any related issues here. e.g., "Fixes #123" -->
Fits with samples PR: https://github.com/Universal-Commerce-Protocol/samples/pull/129

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

<!-- If applicable, add screenshots or log output to help explain your changes. For any edits to the rendering of UCP.dev content, a screenshot is appreciated; for fixes, a before/after comparison is especially helpful for reviewers. -->
