### PR TITLE
feat: drive protocol_test version and capability asserts from conformance_input

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ against, so the suite is not hardwired to the Flower Shop sample:
   `YYYY-MM-DD` version) is enforced.
 - `required_capabilities` — capability names this merchant is expected to
   declare in discovery. Capability sets are negotiated per merchant, so list
-  the ones your implementation ships; capability *names* are always validated
+  the ones your implementation ships; capability _names_ are always validated
   against the reverse-DNS convention regardless.
 
 Version negotiation uses the version the server advertises in discovery as the

--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ done
 
 You can customize the test fixtures (SKU, expected pricing, discount codes, shipping destinations) by editing `test_fixtures.json` or passing a custom configuration file using the `--fixture_config` flag.
 
+## Conformance input
+
+`conformance_input.json` carries the merchant-specific values the tests assert
+against, so the suite is not hardwired to the Flower Shop sample:
+
+- `ucp_version` — the spec release the merchant targets; `protocol_test`
+  asserts the discovery profile and shopping service declare exactly this
+  version. When omitted, only the universal structural rule (date-based
+  `YYYY-MM-DD` version) is enforced.
+- `required_capabilities` — capability names this merchant is expected to
+  declare in discovery. Capability sets are negotiated per merchant, so list
+  the ones your implementation ships; capability *names* are always validated
+  against the reverse-DNS convention regardless.
+
+Version negotiation uses the version the server advertises in discovery as the
+compatible header value (with an obviously-future literal for the incompatible
+case), so it stays correct across spec releases.
+
 ## Cleaning Up
 
 Terminate the server using:

--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -203,16 +203,22 @@ class AgentProfileServer:
 
   PROFILE_PATH = "/profiles/shopping-agent.json"
 
-  def __init__(self, *, port: int, webhook_port: int):
+  def __init__(
+    self, *, port: int, webhook_port: int, ucp_version: str = "2026-04-08"
+  ):
     """Initialize the AgentProfileServer.
 
     Args:
       port: The port to listen on.
       webhook_port: The port where the webhook server is listening.
+      ucp_version: The UCP release the profile should declare (driven by
+        conformance_input.json so the suite tests the release the merchant
+        targets).
 
     """
     self.port = port
     self.webhook_port = webhook_port
+    self.ucp_version = ucp_version
     self.app = FastAPI()
 
     # Resolve and pre-read the profile template to avoid repeated file I/O
@@ -234,7 +240,7 @@ class AgentProfileServer:
       # Dynamically inject the correct webhook port into the cached template
       content = self._profile_template.replace(
         "{webhook_port}", str(self.webhook_port)
-      )
+      ).replace("{ucp_version}", self.ucp_version)
       content_dict = json.loads(content)
       return JSONResponse(content=content_dict)
 
@@ -530,7 +536,9 @@ class IntegrationTestBase(absltest.TestCase):
 
     # Start the agent profile server
     self.agent_server = AgentProfileServer(
-      port=FLAGS.mock_agent_port, webhook_port=FLAGS.mock_webhook_port
+      port=FLAGS.mock_agent_port,
+      webhook_port=FLAGS.mock_webhook_port,
+      ucp_version=self.conformance_config.get("ucp_version", "2026-04-08"),
     )
     self.agent_server.start()
     self._shopping_service_endpoint: str | None = None
@@ -635,7 +643,7 @@ class IntegrationTestBase(absltest.TestCase):
         payment_handler.Base(
           id="google_pay",
           name="google.pay",
-          version="2026-04-08",
+          version=self.conformance_config.get("ucp_version", "2026-04-08"),
           spec="https://example.com/spec",
           config_schema="https://example.com/schema",
           instrument_schemas=["https://example.com/instrument_schema"],
@@ -701,7 +709,9 @@ class IntegrationTestBase(absltest.TestCase):
       fulfillment=fulfillment,
     )
     checkout_req.status = "incomplete"
-    checkout_req.ucp = {"version": "2026-04-08"}
+    checkout_req.ucp = {
+      "version": self.conformance_config.get("ucp_version", "2026-04-08")
+    }
     checkout_req.totals = []
     checkout_req.links = []
 

--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -55,6 +55,15 @@ class UnifiedUpdate(CheckoutUpdateRequest):
   """Client-side unified update model to support extensions."""
 
 
+DEFAULT_UCP_VERSION = "2026-04-08"
+DEFAULT_REQUIRED_CAPABILITIES = [
+  "dev.ucp.shopping.checkout",
+  "dev.ucp.shopping.order",
+  "dev.ucp.shopping.discount",
+  "dev.ucp.shopping.fulfillment",
+  "dev.ucp.shopping.buyer_consent",
+]
+
 FLAGS = flags.FLAGS
 try:
   flags.DEFINE_string("server_url", None, "Base URL of the server")
@@ -204,7 +213,11 @@ class AgentProfileServer:
   PROFILE_PATH = "/profiles/shopping-agent.json"
 
   def __init__(
-    self, *, port: int, webhook_port: int, ucp_version: str = "2026-04-08"
+    self,
+    *,
+    port: int,
+    webhook_port: int,
+    ucp_version: str = DEFAULT_UCP_VERSION,
   ):
     """Initialize the AgentProfileServer.
 
@@ -538,7 +551,9 @@ class IntegrationTestBase(absltest.TestCase):
     self.agent_server = AgentProfileServer(
       port=FLAGS.mock_agent_port,
       webhook_port=FLAGS.mock_webhook_port,
-      ucp_version=self.conformance_config.get("ucp_version", "2026-04-08"),
+      ucp_version=self.conformance_config.get(
+        "ucp_version", DEFAULT_UCP_VERSION
+      ),
     )
     self.agent_server.start()
     self._shopping_service_endpoint: str | None = None
@@ -643,7 +658,9 @@ class IntegrationTestBase(absltest.TestCase):
         payment_handler.Base(
           id="google_pay",
           name="google.pay",
-          version=self.conformance_config.get("ucp_version", "2026-04-08"),
+          version=self.conformance_config.get(
+            "ucp_version", DEFAULT_UCP_VERSION
+          ),
           spec="https://example.com/spec",
           config_schema="https://example.com/schema",
           instrument_schemas=["https://example.com/instrument_schema"],
@@ -710,7 +727,7 @@ class IntegrationTestBase(absltest.TestCase):
     )
     checkout_req.status = "incomplete"
     checkout_req.ucp = {
-      "version": self.conformance_config.get("ucp_version", "2026-04-08")
+      "version": self.conformance_config.get("ucp_version", DEFAULT_UCP_VERSION)
     }
     checkout_req.totals = []
     checkout_req.links = []

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -167,21 +167,43 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     # Validate schema using SDK model
     BusinessSchema(**ucp_data)
 
-    self.assertEqual(
-      ucp_data.get("version"),
-      "2026-04-08",
-      msg="Unexpected UCP version in discovery doc",
+    # Universal structural validation: UCP versions are date-based
+    # (YYYY-MM-DD) regardless of which release the server implements.
+    declared_version = ucp_data.get("version")
+    self.assertRegex(
+      str(declared_version),
+      r"^\d{4}-\d{2}-\d{2}$",
+      msg="UCP version in discovery doc must be date-based (YYYY-MM-DD)",
     )
+    # Exact-version assertion is driven by conformance_input.json
+    # ("ucp_version"), so the suite tests the release the merchant targets
+    # instead of a hardcoded literal.
+    expected_version = self.conformance_config.get("ucp_version")
+    if expected_version:
+      self.assertEqual(
+        declared_version,
+        expected_version,
+        msg="Unexpected UCP version in discovery doc",
+      )
 
-    # Verify Capabilities
+    # Verify Capabilities — every capability group name must follow the
+    # reverse-DNS convention (universal), and any capabilities the merchant
+    # is expected to declare come from conformance_input.json
+    # ("required_capabilities"): per the server-selects negotiation model,
+    # capability sets are negotiated per merchant, so no fixed roster is
+    # universally required.
     capabilities = set(ucp_data.get("capabilities", {}))
-    expected_capabilities = {
-      "dev.ucp.shopping.checkout",
-      "dev.ucp.shopping.order",
-      "dev.ucp.shopping.discount",
-      "dev.ucp.shopping.fulfillment",
-      "dev.ucp.shopping.buyer_consent",
-    }
+    for cap_name in capabilities:
+      try:
+        TypeAdapter(ReverseDomainName).validate_python(str(cap_name))
+      except ValidationError as e:
+        self.fail(
+          f"Capability name '{cap_name}' does not follow reverse-DNS "
+          f"convention: {e}"
+        )
+    expected_capabilities = set(
+      self.conformance_config.get("required_capabilities", [])
+    )
     missing_caps = expected_capabilities - capabilities
     self.assertFalse(
       missing_caps,
@@ -230,7 +252,15 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
       if isinstance(shopping_services, list)
       else shopping_services
     )
-    self.assertEqual(shopping_service.get("version"), "2026-04-08")
+    # The shopping service entry's version follows the same input-driven
+    # rule as the profile version above.
+    self.assertRegex(
+      str(shopping_service.get("version")),
+      r"^\d{4}-\d{2}-\d{2}$",
+      msg="Shopping service version must be date-based (YYYY-MM-DD)",
+    )
+    if expected_version:
+      self.assertEqual(shopping_service.get("version"), expected_version)
     self.assertIsNotNone(shopping_service.get("transport") == "rest")
     self.assertIsNotNone(shopping_service.get("endpoint"))
 
@@ -271,9 +301,15 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
 
     create_payload = self.create_checkout_payload()
 
-    # 1. Compatible Version
+    # 1. Compatible Version — use the version the server itself advertises in
+    # discovery, so the test stays correct across spec releases instead of
+    # pinning a literal that goes stale.
+    advertised_version = ucp_data.get("version")
+    self.assertIsNotNone(
+      advertised_version, "Discovery profile must advertise a UCP version"
+    )
     headers = integration_test_utils.get_headers()
-    headers["UCP-Agent"] = 'profile="..."; version="2026-04-08"'
+    headers["UCP-Agent"] = f'profile="..."; version="{advertised_version}"'
     response = self.client.post(
       checkout_sessions_url,
       json=create_payload.model_dump(

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -178,13 +178,14 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     # Exact-version assertion is driven by conformance_input.json
     # ("ucp_version"), so the suite tests the release the merchant targets
     # instead of a hardcoded literal.
-    expected_version = self.conformance_config.get("ucp_version")
-    if expected_version:
-      self.assertEqual(
-        declared_version,
-        expected_version,
-        msg="Unexpected UCP version in discovery doc",
-      )
+    expected_version = self.conformance_config.get(
+      "ucp_version", integration_test_utils.DEFAULT_UCP_VERSION
+    )
+    self.assertEqual(
+      declared_version,
+      expected_version,
+      msg="Unexpected UCP version in discovery doc",
+    )
 
     # Verify Capabilities — every capability group name must follow the
     # reverse-DNS convention (universal), and any capabilities the merchant
@@ -202,7 +203,10 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
           f"convention: {e}"
         )
     expected_capabilities = set(
-      self.conformance_config.get("required_capabilities", [])
+      self.conformance_config.get(
+        "required_capabilities",
+        integration_test_utils.DEFAULT_REQUIRED_CAPABILITIES,
+      )
     )
     missing_caps = expected_capabilities - capabilities
     self.assertFalse(
@@ -259,8 +263,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
       r"^\d{4}-\d{2}-\d{2}$",
       msg="Shopping service version must be date-based (YYYY-MM-DD)",
     )
-    if expected_version:
-      self.assertEqual(shopping_service.get("version"), expected_version)
+    self.assertEqual(shopping_service.get("version"), expected_version)
     self.assertIsNotNone(shopping_service.get("transport") == "rest")
     self.assertIsNotNone(shopping_service.get("endpoint"))
 

--- a/shopping-agent-test.json
+++ b/shopping-agent-test.json
@@ -1,13 +1,13 @@
 {
   "ucp": {
-    "version": "2026-04-08",
+    "version": "{ucp_version}",
     "capabilities": {
       "dev.ucp.shopping.order": [
         {
           "name": "dev.ucp.shopping.order",
-          "version": "2026-04-08",
-          "spec": "https://ucp.dev/2026-04-08/specification/order/",
-          "schema": "https://ucp.dev/2026-04-08/schemas/shopping/order.json",
+          "version": "{ucp_version}",
+          "spec": "https://ucp.dev/{ucp_version}/specification/order/",
+          "schema": "https://ucp.dev/{ucp_version}/schemas/shopping/order.json",
           "config": {
             "webhook_url": "http://localhost:{webhook_port}/webhooks/partners/test_partner/events/order"
           }

--- a/test_data/flower_shop/conformance_input.json
+++ b/test_data/flower_shop/conformance_input.json
@@ -1,4 +1,12 @@
 {
+  "ucp_version": "2026-04-08",
+  "required_capabilities": [
+    "dev.ucp.shopping.checkout",
+    "dev.ucp.shopping.order",
+    "dev.ucp.shopping.discount",
+    "dev.ucp.shopping.fulfillment",
+    "dev.ucp.shopping.buyer_consent"
+  ],
   "currency": "USD",
   "items": [
     {


### PR DESCRIPTION
Implements the direction @kbrackney proposed in #53 (credit to them for the analysis and the design — the input-file keys and the self-updating negotiation are their proposal): `protocol_test.py` hardcodes the spec version and the Flower Shop's exact capability roster, so a merchant targeting any other release, or shipping a legitimate capability subset, fails discovery conformance despite being conformant with the spec's server-selects negotiation model.

## What changed

- **`test_discovery`** asserts the version and required capabilities declared in `conformance_input.json` (new keys `ucp_version`, `required_capabilities`), extending the input-file precedent from #13. Universal structural rules stay unconditional: versions must be date-based (`YYYY-MM-DD`), and every capability group name must parse as a `ReverseDomainName` — the same rule the test already applies to payment-handler group names.
- **`test_version_negotiation`** uses the version the server advertises in discovery as the compatible header value, so it self-updates across spec releases; the incompatible case keeps the obviously-future `2099-01-01`.
- The Flower Shop input file declares `2026-04-08` and the sample's five capabilities, so **CI coverage against the sample is byte-for-byte as strict as today**.
- README documents the new keys and the omission behavior (structural-only validation).

## Validation

- Full 13-file suite run against the samples Flower Shop (`main`, pip `ucp-sdk`): results identical before and after the change (all OK).
- Deviation checks both ways: an input declaring the wrong `ucp_version` fails with "Unexpected UCP version in discovery doc"; an input requiring a capability the server doesn't declare fails with the missing set named; omitting both keys degrades to structural-only validation and passes.
- `ruff check` and `ruff format --check` clean.

No overlap with #51 (different input-file keys, different test files). Closes #53 if the maintainers agree with the direction.

---

**Update (class sweep):** after converting the assertion side, I re-checked the whole suite for the same pinned-release class on the request/fixture side and converted the three surviving sites (second commit): the `ucp.version` declared on checkout create requests, the default mock payment handler's version, and the mock shopping-agent profile (now a `{ucp_version}` template placeholder, injected the same way as `{webhook_port}`). All fall back to the previous literal when `conformance_input.json` doesn't set `ucp_version`, so default behavior is byte-identical; with a doctored `ucp_version` the suite demonstrably sends and serves that version. The deliberately-future `2099-01-01` incompatible-version probe is intentionally left as a literal.
