### PR TITLE
fix: default buyer in update_checkout_session

### DIFF
--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -1026,6 +1026,9 @@ class IntegrationTestBase(absltest.TestCase):
         else None
       )
 
+    if buyer is None and checkout_obj.buyer is not None:
+      buyer = checkout_obj.buyer.model_dump()
+
     update_payload = UnifiedUpdate(
       id=checkout_obj.id,
       currency=currency,


### PR DESCRIPTION
# Description

Default `buyer` to `checkout_obj.buyer` in `update_checkout_session` if not explicitly provided. This ensures that the buyer information is carried over to the update request, allowing the server to identify the customer and inject stored addresses.

Fixes #24

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, **including removal of schema files or fields**)
- [ ] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
