### PR TITLE
Expect 422 for unsupported version in conformance tests

### DIFF
--- a/protocol_test.py
+++ b/protocol_test.py
@@ -331,7 +331,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
       ),
       headers=headers,
     )
-    self.assert_response_status(response, 400)
+    self.assert_response_status(response, 422)
 
 
 if __name__ == "__main__":

--- a/protocol_test.py
+++ b/protocol_test.py
@@ -276,7 +276,6 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     When the request includes a 'UCP-Agent' header with an incompatible version,
     then the request fails with 400 Bad Request.
     """
-    # Discover shopping service endpoint
     discovery_resp = self.client.get("/.well-known/ucp")
     self.assert_response_status(discovery_resp, 200)
     profile_dict = discovery_resp.json()


### PR DESCRIPTION
Fixes ProtocolTest.test_version_negotiation failure where 422 is returned but 400 was expected.