### PR TITLE
fix: require REST shopping transport in protocol tests

### DIFF
--- a/protocol_test.py
+++ b/protocol_test.py
@@ -264,7 +264,11 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
       msg="Shopping service version must be date-based (YYYY-MM-DD)",
     )
     self.assertEqual(shopping_service.get("version"), expected_version)
-    self.assertIsNotNone(shopping_service.get("transport") == "rest")
+    self.assertEqual(
+      shopping_service.get("transport"),
+      "rest",
+      "Shopping service must advertise the REST transport",
+    )
     self.assertIsNotNone(shopping_service.get("endpoint"))
 
   def test_version_negotiation(self):
@@ -274,7 +278,7 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
     When the request includes a 'UCP-Agent' header with a compatible version,
     then the request succeeds (200/201).
     When the request includes a 'UCP-Agent' header with an incompatible version,
-    then the request fails with 400 Bad Request.
+    then the request fails with 422 Unprocessable Content.
     """
     # Discover shopping service endpoint
     discovery_resp = self.client.get("/.well-known/ucp")
@@ -290,9 +294,10 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
       if isinstance(shopping_services, list)
       else shopping_services
     )
-    self.assertIsNotNone(
-      (shopping_service.get("transport") == "rest"),
-      "REST config not found for shopping service",
+    self.assertEqual(
+      shopping_service.get("transport"),
+      "rest",
+      "Shopping service must advertise the REST transport",
     )
     self.assertIsNotNone(
       shopping_service.get("endpoint"),


### PR DESCRIPTION
# Description

The discovery and version-negotiation tests intended to require the shopping
service to use the REST transport, but they wrapped a boolean comparison in
`assertIsNotNone`. Both `True` and `False` are non-`None`, so a merchant profile
advertising another transport could pass and later be treated as a REST
endpoint.

This change uses an exact equality assertion in both paths. It also aligns the
version-negotiation docstring with the expected `422 Unprocessable Content`
response.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- [x] Regression profile advertising `transport: "mcp"` is rejected
- [x] Positive profile advertising `transport: "rest"` passes
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/ruff format --check .`
- [x] Full conformance suite against the Python Flower Shop sample: 68 passed, 1 skipped
- [x] `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No additional comments are needed for this focused assertion change
- [x] No documentation update is required
- [x] My changes generate no new warnings
- [x] The corrected assertions prove the fix is effective
- [x] New and existing tests pass locally with my changes
- [x] No dependent downstream changes are required

