### PR TITLE
fix: use configured fixed-discount amount in business_logic_test

### DIFF
--- a/business_logic_test.py
+++ b/business_logic_test.py
@@ -390,7 +390,8 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
     )
     self.assertEqual(
       discounts_obj.applied[0].amount,
-      500,
+      expected_discount,
+      "applied discount amount must match the configured fixed reduction",
     )
 
   def test_buyer_consent(self):


### PR DESCRIPTION
## Description

`test_fixed_amount_discount` in `business_logic_test.py` fetched the expected reduction into `expected_discount` and already passed it to `assert_totals_consistent(...)`, but the separate assertion on `discounts.applied[0].amount` hardcoded `500` instead of using that variable:

```python
expected_discount = self.fixture_ctx.get_expected_fixed_discount_reduction()
...
self.assert_totals_consistent(..., expected_discount=expected_discount)   # uses it
...
self.assertEqual(discounts_obj.applied[0].amount, 500)                    # ignores it
```

`get_expected_fixed_discount_reduction()` already returns the value in **minor units** (`expected_fixed_discount_reduction` major units × 100), so the hardcoded `500` only matched the default flower_shop fixture (5.00 → 500) by coincidence. Any non-default fixture (e.g. a configured `7.50` fixed reduction → expected `750`) would pass the totals-consistency check but fail the `applied[0].amount` assertion for the same checkout, an internal contradiction.

**Fix:** assert against `expected_discount`, making the two assertions in the same test consistent and server-agnostic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, **including removal of schema files or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

N/A — test-only fix, no schema/field removal.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A — test-only fix)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
