### PR TITLE
fix: use configured base price in fulfillment total assertion

### DIFF
--- a/fulfillment_test.py
+++ b/fulfillment_test.py
@@ -134,7 +134,9 @@ class FulfillmentTest(integration_test_utils.IntegrationTestBase):
     )
     final_checkout = checkout.Checkout(**response_json)
 
-    expected_total = 3500 + option_cost  # Base 3500 + shipping
+    expected_total = (
+      self.fixture_ctx.get_test_price() + option_cost
+    )  # base price + shipping
     total_obj = next(
       (t for t in final_checkout.totals if t.type == "total"), None
     )


### PR DESCRIPTION
## Description

`test_fulfillment_flow` in `fulfillment_test.py` hardcoded `3500` as the item base price when computing the expected total:

```python
expected_total = 3500 + option_cost  # Base 3500 + shipping
```

Every other test in the suite resolves the item price via `fixture_ctx.get_test_price()`. The hardcoded `3500` only matches the default flower_shop fixture (`valid_item.expected_price` 35.00 → 3500); a fixture configured with a different item price would fail the total assertion even though the server behaved correctly — the same class of "default-only" bug as the recently-fixed hardcoded discount amount.

`get_test_price()` already returns minor units, so this is a pure substitution with no unit conversion.

```python
expected_total = self.fixture_ctx.get_test_price() + option_cost  # base price + shipping
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, **including removal of schema files or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

N/A — test-only fix, no schema/field removal.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A — test-only fix)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
