### PR TITLE
fix: relax over-strict discount applied[] count/position assertions

### DIFF
--- a/business_logic_test.py
+++ b/business_logic_test.py
@@ -247,9 +247,10 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
       discounts_obj and discounts_obj.applied,
       "Applied discounts field missing",
     )
-    self.assertEqual(
-      discounts_obj.applied[0].code,
+    applied_codes = [d.code for d in discounts_obj.applied]
+    self.assertIn(
       valid_code,
+      applied_codes,
       "Applied discounts field incorrect",
     )
 
@@ -349,6 +350,7 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
     self.assertTrue(discounts_obj and discounts_obj.applied)
     applied_codes = [d.code for d in discounts_obj.applied]
     self.assertIn(valid_code, applied_codes)
+    self.assertNotIn("INVALID_CODE", applied_codes)
 
   def test_fixed_amount_discount(self):
     """Test that a fixed-amount discount code decreases the total correctly.
@@ -389,12 +391,10 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
       discounts_obj and discounts_obj.applied,
       "Applied discounts field missing",
     )
+    applied_discounts = {d.code: d for d in discounts_obj.applied if d.code}
+    self.assertIn(fixed_code, applied_discounts)
     self.assertEqual(
-      discounts_obj.applied[0].code,
-      fixed_code,
-    )
-    self.assertEqual(
-      discounts_obj.applied[0].amount,
+      applied_discounts[fixed_code].amount,
       expected_discount,
       "applied discount amount must match the configured fixed reduction",
     )

--- a/business_logic_test.py
+++ b/business_logic_test.py
@@ -300,12 +300,14 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
       discounted_checkout, expected_price, expected_discount=expected_discount
     )
 
-    # Verify both applied discounts are present
+    # Verify both submitted codes are present in the applied list. The applied
+    # list also carries any automatic discounts (discount.md: applied contains
+    # code-based + automatic), so assert membership rather than an exact count.
     discounts_data = getattr(discounted_checkout, "discounts", {})
     discounts_obj = (
       discount.DiscountsObject(**discounts_data) if discounts_data else None
     )
-    self.assertTrue(discounts_obj and len(discounts_obj.applied) == 2)
+    self.assertTrue(discounts_obj and discounts_obj.applied)
     applied_codes = [d.code for d in discounts_obj.applied]
     self.assertIn(valid_code_1, applied_codes)
     self.assertIn(valid_code_2, applied_codes)
@@ -337,13 +339,16 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
       discounted_checkout, expected_price, expected_discount=expected_discount
     )
 
-    # Verify only one applied discount is present
+    # Verify the valid code is present in the applied list. The applied list
+    # also carries any automatic discounts, so assert membership rather than an
+    # exact count or a fixed position (automatic discounts have no code).
     discounts_data = getattr(discounted_checkout, "discounts", {})
     discounts_obj = (
       discount.DiscountsObject(**discounts_data) if discounts_data else None
     )
-    self.assertTrue(discounts_obj and len(discounts_obj.applied) == 1)
-    self.assertEqual(discounts_obj.applied[0].code, valid_code)
+    self.assertTrue(discounts_obj and discounts_obj.applied)
+    applied_codes = [d.code for d in discounts_obj.applied]
+    self.assertIn(valid_code, applied_codes)
 
   def test_fixed_amount_discount(self):
     """Test that a fixed-amount discount code decreases the total correctly.


### PR DESCRIPTION
## Description

Two discount tests in `business_logic_test.py` asserted **exact lengths** (and one a **fixed position**) on `discounts.applied[]`, but per `discount.md` the `applied` list carries code-based discounts **plus any automatic discounts**, whose count is not fixed and whose `code` is `null`. A conformant business that also applies an automatic discount would fail these assertions even though every submitted code is correctly present.

### `test_multiple_discounts_accepted`

```python
self.assertTrue(discounts_obj and len(discounts_obj.applied) == 2)   # too strict
applied_codes = [d.code for d in discounts_obj.applied]
self.assertIn(valid_code_1, applied_codes)
self.assertIn(valid_code_2, applied_codes)
```

The two `assertIn(code)` checks already prove both submitted codes were applied, so the `len == 2` adds nothing except a failure mode when an automatic discount coexists. Relaxed to `assertTrue(discounts_obj.applied)`.

### `test_multiple_discounts_one_rejected`

```python
self.assertTrue(discounts_obj and len(discounts_obj.applied) == 1)   # too strict
self.assertEqual(discounts_obj.applied[0].code, valid_code)          # assumes position
```

Two issues: the exact count, and `applied[0]` assuming the code-based discount is first — an automatic discount ordered ahead of it has `code = null` and fails the equality. Replaced with a position-independent membership check.

`assertIn` is safe against a list that may contain `None` entries (automatic discounts), since the submitted code is always a string.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, **including removal of schema files or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

N/A — test-only fix, no schema/field removal.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A — test-only fix)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
