### PR TITLE
fix: route invalid_input order requests through the discovered endpoint

### DIFF
--- a/invalid_input_test.py
+++ b/invalid_input_test.py
@@ -49,7 +49,7 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order
     response = self.client.get(
-      f"/orders/{order_id}", headers=self.get_headers()
+      self.get_order_url(order_id), headers=self.get_headers()
     )
     order_obj = order.Order(**response.json())
     order_dict = order_obj.model_dump(
@@ -71,7 +71,7 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Update Order
     resp = self.client.put(
-      f"/orders/{order_id}",
+      self.get_order_url(order_id),
       json=order_dict,
       headers=self.get_headers(),
     )
@@ -116,7 +116,7 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Get Order
     response = self.client.get(
-      f"/orders/{order_id}", headers=self.get_headers()
+      self.get_order_url(order_id), headers=self.get_headers()
     )
     order_obj = order.Order(**response.json())
     order_dict = order_obj.model_dump(
@@ -128,7 +128,7 @@ class InvalidInputTest(integration_test_utils.IntegrationTestBase):
 
     # Update Order
     resp = self.client.put(
-      f"/orders/{order_id}",
+      self.get_order_url(order_id),
       json=order_dict,
       headers=self.get_headers(),
     )


### PR DESCRIPTION
## Description

The four order `GET`/`PUT` calls in `invalid_input_test.py` used a raw `"/orders/{order_id}"` path against the httpx `base_url`, while **every** order call in `order_test.py` goes through `self.get_order_url(order_id)`, which resolves the shopping-service endpoint discovered from `/.well-known/ucp`:

```python
def get_order_url(self, order_id: str) -> str:
    return self.get_shopping_url(f"/orders/{order_id}")   # {discovered_endpoint}/orders/{id}
```

The raw path only works when the shopping service is hosted at the server root. For a conformant server whose shopping service lives at a sub-path, these requests 404 before validation ever runs — so `test_invalid_adjustment_status` and `test_malformed_adjustment_payload` would fail (or pass) for the wrong reason (404 instead of the intended 422) instead of exercising the intended validation path.

Switched all four to `get_order_url` to match the rest of the suite. Behavior is unchanged for the sample server, whose shopping endpoint is at the root.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, **including removal of schema files or fields**)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

N/A — test-only fix, no schema/field removal.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A — test-only fix)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
