### PR TITLE
fix: sum all non-total entries per the spec formula in assert_totals_consistent

### DIFF
--- a/business_logic_test.py
+++ b/business_logic_test.py
@@ -46,23 +46,34 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
   def assert_totals_consistent(
     self, checkout_obj, expected_subtotal, expected_discount=0
   ):
-    """Assert that the checkout totals are consistent and correct."""
+    """Assert that the checkout totals are consistent and correct.
+
+    The grand total is verified with the spec's own formula (checkout.md
+    "Verification"): sum of the signed amounts of every non-``total``
+    entry equals the ``total`` entry's amount. Every entry participates:
+    all types except ``subtotal``/``total`` MAY repeat (checkout.md
+    "Repeating Types" — e.g. multi-jurisdiction tax lines or itemized
+    fees) and ``type`` is an open string, so picking one entry per
+    well-known type would both reject conformant servers and miss
+    servers whose total drops a repeated or custom entry.
+    """
     subtotal = next(
       (t.amount for t in checkout_obj.totals if t.type == "subtotal"), 0
     )
-    fulfillment = next(
-      (t.amount for t in checkout_obj.totals if t.type == "fulfillment"), 0
-    )
-    tax = next((t.amount for t in checkout_obj.totals if t.type == "tax"), 0)
-    fee = next((t.amount for t in checkout_obj.totals if t.type == "fee"), 0)
     discount = sum(
       t.amount
       for t in checkout_obj.totals
       if t.type in ["items_discount", "discount"]
     )
-    total = next(
-      (t.amount for t in checkout_obj.totals if t.type == "total"), 0
+    total_entries = [t for t in checkout_obj.totals if t.type == "total"]
+    self.assertLen(
+      total_entries,
+      1,
+      "Exactly one totals entry of type 'total' must be present "
+      "(checkout.md totals invariants), got "
+      f"{[(t.type, t.amount) for t in checkout_obj.totals]}",
     )
+    total = total_entries[0].amount
 
     self.assertEqual(
       subtotal,
@@ -85,14 +96,19 @@ class BusinessLogicTest(integration_test_utils.IntegrationTestBase):
           expected_discount,
           f"Discount mismatch: expected {expected_discount}, got {discount}",
         )
-    calculated_total = subtotal + fulfillment + tax + fee - abs(discount)
+    # checkout.md "Verification":
+    #   assert sum(e.amount for e in totals if e.type != "total") \
+    #     == total_entry.amount
+    # Amounts are signed integers; the sign IS the direction.
+    calculated_total = sum(
+      t.amount for t in checkout_obj.totals if t.type != "total"
+    )
     self.assertEqual(
       total,
       calculated_total,
       (
-        f"Total math mismatch: calculated {calculated_total} (subtotal="
-        f"{subtotal}, fulfillment={fulfillment}, tax={tax}, fee={fee}, "
-        f"discount={discount}), got {total}"
+        f"Total math mismatch: calculated {calculated_total} from entries "
+        f"{[(t.type, t.amount) for t in checkout_obj.totals]}, got {total}"
       ),
     )
 


### PR DESCRIPTION
## Observed

`assert_totals_consistent` (business_logic_test.py) computes the expected total as `subtotal + fulfillment + tax + fee - abs(discount)`, taking each well-known type with `next()` — i.e. the FIRST entry only — and ignoring any other total type. Per the 2026-04-08 spec this false-fails conformant servers:

- checkout.md ("Repeating Types"): *"All types except `subtotal` and `total` MAY appear multiple times — for example, multi-jurisdiction tax lines or itemized fees"*, and *"the `type` field is an open string"*. A server with two tax lines, itemized fees, or a custom entry (e.g. `duty`, `account_credit`) fails "Total math mismatch" even when its totals are correct — including checkout.md's own Split-tax and account_credit examples.

The check is also unsound in the other direction: because it sums only the first entry per type, a server whose `total` genuinely omits a repeated tax line PASSES, and duplicate `total` entries pass.

## Fix

Use the spec's own Verification formula (checkout.md): `sum(e.amount for e in totals if e.type != "total") == total_entry.amount` — a signed sum over all non-`total` entries (amounts are signed; discounts are negative, so no special-casing). Add the spec's exactly-one-`total` invariant. The configured-subtotal and expected-discount equality checks are unchanged.

This both relaxes (accepts spec-legal repeating/custom types) and tightens (now catches a total that drops a repeated entry, and duplicate totals).

## Verification

- A spec-example-driven driver: the old check false-failed 4 conformant shapes (checkout.md's Split-tax and account_credit examples verbatim, two-fee-line, custom `duty`); the new check accepts all and still fails a genuinely wrong total, wrong subtotal, wrong discount, a dropped repeated entry, and duplicate totals.
- All 6 call sites pass against the reference. The full official suite passes on both the Python and Node reference servers (17/17 each).
