### PR TITLE
fix: accept the spec's in-band posture for payment failure (drop 402/prose pin)

### DIFF
--- a/validation_test.py
+++ b/validation_test.py
@@ -341,7 +341,11 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
     Given a checkout session ready for completion,
     When a payment instrument with a known failing token ('fail_token') is
     submitted,
-    Then the server should return a 402 Payment Required error.
+    Then the server either rejects with a 4xx describing the payment
+    problem, or answers in-band per the spec's error model with a typed
+    'payment_failed' error message (checkout.md standard error codes /
+    error_code.json; checkout-rest.md "Error Responses": business
+    outcomes return HTTP 200 with the UCP envelope and messages[]).
     """
     response_json = self.create_checkout_session(handlers=[])
     checkout_id = checkout.Checkout(**response_json).id
@@ -358,10 +362,10 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
       headers=integration_test_utils.get_headers(),
     )
 
-    self.assert_4xx_error(
+    self.assert_business_error(
       response,
-      expected_status=402,
-      substring="Payment Failed",
+      accepted_codes={"payment_failed"},
+      error_4xx_substring="payment",
     )
 
   def test_complete_without_fulfillment(self) -> None:


### PR DESCRIPTION
## Observed

`test_payment_failure` (validation_test.py) asserts the payment-failure response is HTTP **402** with the substring **"Payment Failed"**. Both are stricter than the 2026-04-08 spec:

- **402 is not in the spec.** It appears nowhere in the 04-08 docs or schemas. `payment_failed` is a standard error message *code* (checkout.md error-code table; `types/error_code.json`), and checkout-rest.md ("Error Responses") states business outcomes *"Return HTTP 200 with UCP envelope and `messages` array."* So a spec-conformant server returning 200 + a `messages[]` entry with `code: payment_failed` fails this check.
- **The prose is the sample's mock string** (`samples/rest/python/server/services/checkout_service.py`: "Payment Failed: Insufficient Funds (Mock)"), not a spec-mandated message. Any conformant server with different wording fails.

## Fix

Use the file's own dual-posture helper `assert_business_error(response, accepted_codes={"payment_failed"}, error_4xx_substring="payment")` — already used by `test_out_of_stock` and `test_structured_error_messages` in the same file. This accepts either the in-band 200 + `messages[code=payment_failed]` posture or a payment-related 4xx, without pinning 402 or asserting sample prose.

## Verification

The relaxed check still catches a genuinely non-conformant server: a server that silently completes the checkout (200, `status: completed`), returns a wrong/missing error code, a broken envelope, or a non-answer all still fail. The reference server's existing 402 posture still passes (no regression), and `validation_test.py` passes on both the Python and Node references.
