### PR TITLE
fix: use configured discount code in totals test

### DIFF
--- a/totals_test.py
+++ b/totals_test.py
@@ -47,11 +47,6 @@ _ADDITIVE_TYPES = frozenset({"subtotal", "fulfillment", "tax", "fee"})
 # Entry types whose amount MUST be negative (total.json: exclusiveMaximum 0).
 _NEGATIVE_TYPES = frozenset({"discount", "items_discount"})
 
-# A percentage discount code recognized by the reference data set. If the
-# server under test does not recognize it, the discount-sign test skips.
-_DISCOUNT_CODE = "10OFF"
-
-
 class TotalsTest(integration_test_utils.IntegrationTestBase):
   """Structural-integrity tests for the checkout ``totals`` breakdown.
 
@@ -85,8 +80,9 @@ class TotalsTest(integration_test_utils.IntegrationTestBase):
     """
     checkout_json = self.create_checkout_session(select_fulfillment=True)
     checkout_obj = checkout.Checkout(**checkout_json)
+    discount_code = self.fixture_ctx.get_test_discount_code()
     updated = self.update_checkout_session(
-      checkout_obj, discounts={"codes": [_DISCOUNT_CODE]}
+      checkout_obj, discounts={"codes": [discount_code]}
     )
     totals = updated.get("totals")
     self.assertIsInstance(

--- a/totals_test.py
+++ b/totals_test.py
@@ -47,6 +47,7 @@ _ADDITIVE_TYPES = frozenset({"subtotal", "fulfillment", "tax", "fee"})
 # Entry types whose amount MUST be negative (total.json: exclusiveMaximum 0).
 _NEGATIVE_TYPES = frozenset({"discount", "items_discount"})
 
+
 class TotalsTest(integration_test_utils.IntegrationTestBase):
   """Structural-integrity tests for the checkout ``totals`` breakdown.
 


### PR DESCRIPTION
## Description

`totals_test.py` defined a module-level `_DISCOUNT_CODE` and used it when driving the discounted checkout helper:

```python
# A percentage discount code recognized by the reference data set. If the
# server under test does not recognize it, the discount-sign test skips.
_DISCOUNT_CODE = "10OFF"
...
updated = self.update_checkout_session(
  checkout_obj, discounts={"codes": [_DISCOUNT_CODE]}
)
```

The rest of the conformance suite reads the test discount code through
`fixture_ctx.get_test_discount_code()`, which comes from `valid_discount_code` in
the configured fixture data with the existing fallback chain. The hardcoded
`"10OFF"` only matches the default fixture. A server tested with a non-default
fixture, for example `"PROMO20"`, would receive an unrecognized discount code,
return no `discount` totals entry, and make `test_discount_entry_is_negative`
skip instead of checking the negative-sign invariant.

**Fix:** use `self.fixture_ctx.get_test_discount_code()` in
`_discounted_checkout_totals()` so the totals sign test applies the same discount
code as the active fixture.

## Category (Required)

- [ ] **Core Protocol**: Changes to core UCP JSON schemas, protocol behavior, or specification semantics. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to contribution process, governance, or project policy. (Requires Governance Council approval)
- [ ] **Capability**: Additions or changes to optional protocol capabilities. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI, build, release, or repository infrastructure changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency updates, cleanup, or non-functional maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization health files, templates, or community metadata. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, including removal of schema files or fields)
- [ ] Documentation update

---

### Is this a Breaking Change or Removal?

N/A — test-only fix, no schema/field removal.

## Checklist

- [x] I have followed the Contributing Guide for this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — test-only conformance fix.
