### PR TITLE
fix: use checkout line item ids in order fulfillment tests

### DIFF
--- a/order_test.py
+++ b/order_test.py
@@ -96,7 +96,7 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
       "methods": [
         {
           "id": "method_1",
-          "line_item_ids": ["item_123"],
+          "line_item_ids": [checkout_obj.line_items[0].id],
           "type": "shipping",
           "destinations": [fulfillment_address],
           "selected_destination_id": "dest_manual",
@@ -149,7 +149,9 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     update_payload["fulfillment"]["methods"][0]["groups"] = [
       {
         "id": group_info.get("id", "group_1"),
-        "line_item_ids": group_info.get("line_item_ids", ["item_123"]),
+        "line_item_ids": group_info.get(
+          "line_item_ids", [checkout_obj.line_items[0].id]
+        ),
         "selected_option_id": option_id,
       }
     ]
@@ -212,7 +214,7 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
       "methods": [
         {
           "id": "method_1",
-          "line_item_ids": ["item_123"],
+          "line_item_ids": [checkout_obj.line_items[0].id],
           "type": "shipping",
           "destinations": [addr],
           "selected_destination_id": "dest_manual_2",
@@ -258,7 +260,9 @@ class OrderTest(integration_test_utils.IntegrationTestBase):
     update_payload["fulfillment"]["methods"][0]["groups"] = [
       {
         "id": group_info.get("id", "group_1"),
-        "line_item_ids": group_info.get("line_item_ids", ["item_123"]),
+        "line_item_ids": group_info.get(
+          "line_item_ids", [checkout_obj.line_items[0].id]
+        ),
         "selected_option_id": options[0]["id"],
       }
     ]


### PR DESCRIPTION
## Description

`order_test.py` copied the real checkout line items into the update payload:

```python
"line_items": [
  {
    "item": {"id": li.item.id, "title": li.item.title},
    "quantity": li.quantity,
    "id": li.id,
  }
  for li in checkout_obj.line_items
]
```

The fulfillment method in the same payload still used a fixture-specific fallback:

```python
"line_item_ids": ["item_123"]
```

That value does not come from the checkout response, so a merchant implementation with different line item IDs can receive a fulfillment selection that references no line item in the current checkout.

**Fix:** use `checkout_obj.line_items[0].id` for the fulfillment method and group fallback IDs, matching the line items already sent in the same request.

## Category (Required)

- [ ] **Core Protocol**: Changes to the core UCP specification. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: Changes to a UCP capability. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD or repository infrastructure changes. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency or repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Changes to organization community health files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and Code of Conduct.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under python_sdk (not applicable).

## Screenshots / Logs (if applicable)

- `uv run python order_test.py --server_url=http://localhost:8182 --simulation_secret=super-secret-sim-key --test_data_dir=test_data/flower_shop`: 4 passed
- `pre-commit run --all-files`: passed
- `git diff --check`: passed