### PR TITLE
fix: use checkout line item ids in webhook tests

### DIFF
--- a/webhook_test.py
+++ b/webhook_test.py
@@ -133,7 +133,11 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
       checkout_obj,
       fulfillment={
         "methods": [
-          {"id": "method_1", "line_item_ids": ["item_123"], "type": "shipping"}
+          {
+            "id": "method_1",
+            "line_item_ids": [checkout_obj.line_items[0].id],
+            "type": "shipping",
+          }
         ]
       },
     )
@@ -163,7 +167,7 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
           "methods": [
             {
               "id": "method_1",
-              "line_item_ids": ["item_1"],
+              "line_item_ids": [checkout_obj.line_items[0].id],
               "type": "shipping",
               "selected_destination_id": dest_id,
             }
@@ -188,13 +192,13 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
             "methods": [
               {
                 "id": "method_1",
-                "line_item_ids": ["item_1"],
+                "line_item_ids": [checkout_obj.line_items[0].id],
                 "type": "shipping",
                 "selected_destination_id": dest_id,
                 "groups": [
                   {
                     "id": "group_1",
-                    "line_item_ids": ["item_1"],
+                    "line_item_ids": [checkout_obj.line_items[0].id],
                     "selected_option_id": option_id,
                   }
                 ],
@@ -237,7 +241,7 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
       "methods": [
         {
           "id": "method_1",
-          "line_item_ids": ["item_123"],
+          "line_item_ids": [checkout_obj.line_items[0].id],
           "type": "shipping",
           "destinations": [new_address],
           "selected_destination_id": "dest_new_webhook",
@@ -262,13 +266,15 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
       fulfillment_payload["methods"][0]["groups"] = [
         {
           "id": "group_1",
-          "line_item_ids": ["item_123"],
+          "line_item_ids": [checkout_obj.line_items[0].id],
           "selected_option_id": option_id,
         }
       ]
       fulfillment_payload["methods"][0]["type"] = "shipping"
       fulfillment_payload["methods"][0]["id"] = "method_1"
-      fulfillment_payload["methods"][0]["line_item_ids"] = ["item_123"]
+      fulfillment_payload["methods"][0]["line_item_ids"] = [
+        checkout_obj.line_items[0].id
+      ]
       self.update_checkout_session(
         checkout_obj, fulfillment=fulfillment_payload
       )


### PR DESCRIPTION
## Summary
- Replace hardcoded `item_123`/`item_1` fulfillment line_item_ids with the checkout's actual line item ids in `webhook_test.py`.
- Mirrors the pattern already merged in #81 for `order_test.py`.

## Test plan
- [x] `uv run python webhook_test.py --server_url=... --simulation_secret=... --conformance_input=... --fixture_config=...` — 3/3 pass
- [x] `uvx ruff check webhook_test.py` / `uvx ruff format --check webhook_test.py`
- [x] `git diff --check`