### PR TITLE
test: cover webhook retry delivery identity

### DIFF
--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -319,7 +319,9 @@ class MockWebhookServer:
     """Set up the routes for the mock server."""
 
     @self.app.post("/webhooks/partners/{partner_id}/events/order")
-    async def order_event(partner_id: str, request: Request) -> dict[str, str]:
+    async def order_event(
+      partner_id: str, request: Request
+    ) -> JSONResponse | dict[str, str]:
       """Record an incoming order event."""
       # Keep the raw bytes: Content-Digest (RFC 9530) is computed over the
       # body as transmitted, and verifiers must not re-serialize JSON.

--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -298,16 +298,19 @@ class AgentProfileServer:
 class MockWebhookServer:
   """A background mock webhook server that records incoming events."""
 
-  def __init__(self, port: int):
+  def __init__(self, port: int, failures_before_success: int = 0):
     """Initialize the MockWebhookServer.
 
     Args:
       port: The port to listen on.
+      failures_before_success: Number of initial delivery attempts to reject
+        with HTTP 500 after recording them.
 
     """
     self.port = port
-    self.app = FastAPI()
+    self.failures_before_success = failures_before_success
     self.events: list[dict[str, Any]] = []
+    self.app = FastAPI()
     self._setup_routes()
     self._server: uvicorn.Server | None
     self._thread: threading.Thread | None
@@ -323,14 +326,22 @@ class MockWebhookServer:
       raw_body = await request.body()
       payload = json.loads(raw_body)
       headers = dict(request.headers)
+      response_status = (
+        500 if len(self.events) < self.failures_before_success else 200
+      )
       self.events.append(
         {
           "partner_id": partner_id,
           "payload": payload,
           "headers": headers,
           "raw_body": raw_body,
+          "response_status": response_status,
         }
       )
+      if response_status == 500:
+        return JSONResponse(
+          status_code=response_status, content={"status": "retry"}
+        )
       return {"status": "ok"}
 
     @self.app.get("/healthz")

--- a/webhook_structure_test.py
+++ b/webhook_structure_test.py
@@ -210,12 +210,7 @@ class WebhookStructureTest(integration_test_utils.IntegrationTestBase):
 
   def test_transient_failure_retries_preserve_event_identity(self) -> None:
     """A failed delivery is retried as the same webhook event."""
-    self.webhook_server.stop()
-    port = integration_test_utils.FLAGS.mock_webhook_port
-    self.webhook_server = integration_test_utils.MockWebhookServer(
-      port=port, failures_before_success=1
-    )
-    self.webhook_server.start()
+    self.webhook_server.failures_before_success = 1
 
     checkout_data = self.create_checkout_session(headers=self.get_headers())
     checkout_id = checkout_data["id"]
@@ -231,10 +226,18 @@ class WebhookStructureTest(integration_test_utils.IntegrationTestBase):
     )
     self.assertEqual(deliveries[0]["response_status"], 500)
     self.assertEqual(deliveries[1]["response_status"], 200)
+    self.assertTrue(
+      deliveries[0]["headers"].get("webhook-id"),
+      "delivery is missing the required Webhook-Id header",
+    )
     self.assertEqual(
       len({delivery["headers"].get("webhook-id") for delivery in deliveries}),
       1,
       "retry attempts must preserve the Webhook-Id of the original event",
+    )
+    self.assertTrue(
+      deliveries[0]["headers"].get("webhook-timestamp"),
+      "delivery is missing the required Webhook-Timestamp header",
     )
     self.assertEqual(
       len(

--- a/webhook_structure_test.py
+++ b/webhook_structure_test.py
@@ -208,6 +208,53 @@ class WebhookStructureTest(integration_test_utils.IntegrationTestBase):
       f"Webhook-Timestamp {timestamp} does not parse as unix seconds",
     )
 
+  def test_transient_failure_retries_preserve_event_identity(self) -> None:
+    """A failed delivery is retried as the same webhook event."""
+    self.webhook_server.stop()
+    port = integration_test_utils.FLAGS.mock_webhook_port
+    self.webhook_server = integration_test_utils.MockWebhookServer(
+      port=port, failures_before_success=1
+    )
+    self.webhook_server.start()
+
+    checkout_data = self.create_checkout_session(headers=self.get_headers())
+    checkout_id = checkout_data["id"]
+    complete_response = self.complete_checkout_session(checkout_id)
+    order_id = complete_response["order"]["id"]
+    deliveries = self._wait_for_events(order_id, 2)
+
+    self.assertGreaterEqual(
+      len(deliveries),
+      2,
+      "failed webhook delivery was not retried (order.md: MUST retry failed "
+      "webhook deliveries)",
+    )
+    self.assertEqual(deliveries[0]["response_status"], 500)
+    self.assertEqual(deliveries[1]["response_status"], 200)
+    self.assertEqual(
+      len({delivery["headers"].get("webhook-id") for delivery in deliveries}),
+      1,
+      "retry attempts must preserve the Webhook-Id of the original event",
+    )
+    self.assertEqual(
+      len(
+        {
+          delivery["headers"].get("webhook-timestamp")
+          for delivery in deliveries
+        }
+      ),
+      1,
+      "retry attempts must preserve the Webhook-Timestamp of the original "
+      "event",
+    )
+    self.assertTrue(
+      all(
+        delivery["payload"] == deliveries[0]["payload"]
+        for delivery in deliveries
+      ),
+      "retry attempts must carry the same full order entity",
+    )
+
   # ── order.md "Events": fully populated order entity ─────────────────────
   def test_order_created_event_is_full_order_entity(self) -> None:
     """The 'Order created' delivery body is the full order entity."""


### PR DESCRIPTION
## Summary

Adds conformance coverage for the order-event webhook retry requirement.

- Lets the mock webhook receiver reject an initial configurable number of delivery attempts with HTTP 500 while retaining every attempt.
- Verifies an order-event delivery is retried after one transient failure.
- Verifies retry attempts preserve `Webhook-Id`, `Webhook-Timestamp`, and the full order payload.

## Validation

- `uv run python webhook_structure_test.py --server_url=http://localhost:8182 --simulation_secret=super-secret-sim-key --conformance_input=test_data/flower_shop/conformance_input.json --fixture_config=test_data/flower_shop/test_fixtures.json --test_data_dir=test_data/flower_shop`
- `uv run ruff check integration_test_utils.py webhook_structure_test.py`
- `uv run ruff format --check integration_test_utils.py webhook_structure_test.py`
- `uvx --from pre-commit --directory /Users/bytedance/All/UCP/conformance-candidate-23 pre-commit run --all-files`
- `git diff --check`
