### PR TITLE
fix: use configured customer fixture in webhook address tests

### DIFF
--- a/webhook_test.py
+++ b/webhook_test.py
@@ -124,7 +124,15 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
 
   def test_webhook_order_address_known_customer(self) -> None:
     """Test that webhook contains correct address for known customer/address."""
-    buyer_info = {"fullName": "John Doe", "email": "john.doe@example.com"}
+    customer = self.fixture_ctx.get_known_customer()
+    if not customer or not customer.get("addresses"):
+      self.skipTest(
+        "No known customer with stored addresses configured in fixtures."
+      )
+    buyer_info = {
+      "fullName": customer.get("full_name", ""),
+      "email": customer["email"],
+    }
     checkout_data = self.create_checkout_session(buyer=buyer_info)
     checkout_obj = checkout.Checkout(**checkout_data)
 
@@ -151,11 +159,13 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
       and checkout_obj.model_extra.get("fulfillment")
       and checkout_obj.model_extra["fulfillment"].get("methods")
     )
+    selected_destination = None
     if checkout_obj.model_extra["fulfillment"]["methods"][0].get(
       "destinations"
     ):
       method = checkout_obj.model_extra["fulfillment"]["methods"][0]
-      dest_id = method["destinations"][0]["id"]
+      selected_destination = method["destinations"][0]
+      dest_id = selected_destination["id"]
       # Select destination first to calculate options
       self.update_checkout_session(
         checkout_obj,
@@ -218,11 +228,27 @@ class WebhookTest(integration_test_utils.IntegrationTestBase):
     self.assertIsNotNone(event)
     expectations = event["payload"]["fulfillment"]["expectations"]
     self.assertTrue(expectations)
-    self.assertEqual(expectations[0]["destination"]["address_country"], "US")
+    destination = expectations[0]["destination"]
+    self.assertIsNotNone(selected_destination)
+    for field in (
+      "street_address",
+      "address_locality",
+      "address_region",
+      "postal_code",
+      "address_country",
+    ):
+      if field in selected_destination:
+        self.assertEqual(destination.get(field), selected_destination[field])
 
   def test_webhook_order_address_new_address(self) -> None:
     """Test that webhook contains correct address when a new one is provided."""
-    buyer_info = {"fullName": "John Doe", "email": "john.doe@example.com"}
+    customer = self.fixture_ctx.get_known_customer()
+    if not customer:
+      self.skipTest("No known customer configured in fixtures.")
+    buyer_info = {
+      "fullName": customer.get("full_name", ""),
+      "email": customer["email"],
+    }
     checkout_data = self.create_checkout_session(buyer=buyer_info)
     checkout_obj = checkout.Checkout(**checkout_data)
 


### PR DESCRIPTION
## Description

The two webhook address tests hardcoded the flower-shop customer instead of
using the configured fixture:

```python
buyer_info = {"fullName": "John Doe", "email": "john.doe@example.com"}
...
self.assertEqual(expectations[0]["destination"]["address_country"], "US")
```

`--fixture_config` is a supported conformance input, and
`DynamicFixtureContext.get_known_customer()` already provides the customer a
merchant declares. A valid configuration with a different customer would send
the wrong buyer, while a selected non-US destination would be rejected even
when the webhook reproduced it correctly.

**Fix:** build both buyers from `get_known_customer()`, skip the tests when the
optional fixture is absent, and compare the webhook destination with the actual
destination selected from the checkout response rather than a hardcoded
country. The explicit new-address assertions (`CA` / `Webhook St`) remain
unchanged.

## Category (Required)

- [ ] **Core Protocol**: ...
- [ ] **Governance/Contributing**: ...
- [ ] **Capability**: ...
- [ ] **Documentation**: ...
- [ ] **Infrastructure**: ...
- [ ] **Maintenance**: ...
- [ ] **SDK**: ...
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: ...

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide ...
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under python_sdk. (Not applicable: conformance test-only change.)

## Screenshots / Logs (if applicable)

N/A — `webhook_test.py` passed 3/3 against the local Python sample merchant server. `ruff check`, `ruff format --check`, full pre-commit, and `git diff --check` also passed.
