### PR TITLE
fix: accept in-band missing fulfillment errors

### DIFF
--- a/validation_test.py
+++ b/validation_test.py
@@ -374,7 +374,8 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
     Given a newly created checkout session without fulfillment details,
     When a completion request is submitted,
     Then the server either rejects with a 4xx describing the fulfillment
-    problem, or returns an in-band error message with code 'missing'.
+    problem, or returns an in-band error message with code 'missing' or
+    'field_required'.
     """
     response_json = self.create_checkout_session(select_fulfillment=False)
     checkout_id = response_json["id"]
@@ -389,7 +390,7 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
 
     self.assert_business_error(
       response,
-      accepted_codes={"missing"},
+      accepted_codes={"missing", "field_required"},
       error_4xx_substring="fulfillment",
     )
 

--- a/validation_test.py
+++ b/validation_test.py
@@ -373,7 +373,8 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
 
     Given a newly created checkout session without fulfillment details,
     When a completion request is submitted,
-    Then the server should return a 400 Bad Request error.
+    Then the server either rejects with a 4xx describing the fulfillment
+    problem, or returns an in-band error message with code 'missing'.
     """
     response_json = self.create_checkout_session(select_fulfillment=False)
     checkout_id = response_json["id"]
@@ -386,10 +387,10 @@ class ValidationTest(integration_test_utils.IntegrationTestBase):
       headers=integration_test_utils.get_headers(),
     )
 
-    self.assert_4xx_error(
+    self.assert_business_error(
       response,
-      expected_status=400,
-      substring="Fulfillment address and option must be selected",
+      accepted_codes={"missing"},
+      error_4xx_substring="fulfillment",
     )
 
   def test_structured_error_messages(self) -> None:


### PR DESCRIPTION
## Description

`test_complete_without_fulfillment` in `validation_test.py` required the
reference server's exact transport posture and message:

```python
self.assert_4xx_error(
  response,
  expected_status=400,
  substring="Fulfillment address and option must be selected",
)
```

The checkout error model also permits business failures in-band on the existing
resource: a 2xx response with a typed `messages[]` error while the checkout
remains non-completed. The same test file already handles both postures through
`assert_business_error(...)` for out-of-stock, unavailable-item, not-found, and
payment failures. The official playground uses code `missing` for a missing
fulfillment destination.

**Fix:** use the existing dual-posture helper with `missing` for the in-band
case and a case-insensitive `fulfillment` substring for a 4xx rejection.

## Category (Required)

- [ ] **Core Protocol**: Changes to the core UCP protocol. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Changes to governance or contributing processes. (Requires Governance Council approval)
- [ ] **Capability**: New or updated UCP capabilities. (Requires Maintainer approval)
- [ ] **Documentation**: Documentation-only changes. (Requires Maintainer approval)
- [ ] **Infrastructure**: Build, CI, and repository infrastructure. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Dependency and repository maintenance. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the ucp-schema tool. (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Organization-wide community files. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the Contributing Guide and the project's style guidelines.
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`.

## Screenshots / Logs (if applicable)

- `validation_test.py`: 6/6 passed against the reference Python server
- Full conformance CI loop: all 17 `*_test.py` files passed
- `pre-commit run --all-files`: passed
