### PR TITLE
docs: fix discount fixture percentage keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Example `test_fixtures.json`:
       "quantity": 1
     },
     "valid_discount_code": "PROMO10",
-    "expected_discount_reduction": 1.0,
+    "expected_discount_percentage": 10.0,
     "valid_discount_code_2": "PROMO20",
-    "expected_discount_reduction_2": 1.8,
+    "expected_discount_percentage_2": 20.0,
     "valid_fixed_discount_code": "FIXED5",
     "expected_fixed_discount_reduction": 5.0,
     "known_customer": {
@@ -120,8 +120,8 @@ Example `test_fixtures.json`:
 
 - `valid_item`: The SKU and expected price (in major units, e.g., `10.00`) of the item used in tests.
 - **Discounts Configuration**:
-  - `valid_discount_code` & `expected_discount_reduction`: **Required** for basic discount flow tests. The code must be valid on your server, and the reduction is the expected amount in major units.
-  - `valid_discount_code_2` & `expected_discount_reduction_2`: **Optional**. Used for testing multiple discount codes applied sequentially. If your server does not support multiple discounts or you don't configure this, the corresponding test will be skipped.
+  - `valid_discount_code` & `expected_discount_percentage`: **Required** for basic discount flow tests. The code must be valid on your server, and the percentage is expressed as a number from 0 to 100.
+  - `valid_discount_code_2` & `expected_discount_percentage_2`: **Optional**. Used for testing multiple discount codes applied sequentially. If your server does not support multiple discounts or you don't configure this, the corresponding test will be skipped.
   - `valid_fixed_discount_code` & `expected_fixed_discount_reduction`: **Optional**. Used for testing fixed-amount discounts. If your server only supports percentage discounts or you don't configure this, the test will be skipped.
 - **Fulfillment Configuration**:
   - `known_customer`: **Optional**. A buyer your server recognizes by email and stores addresses for, with the stored address contents (response-schema field names). Used by the stored-address injection, selection, and reuse tests; each skips if this is not configured. Address ids are read from your server's responses, so only the contents must match.


### PR DESCRIPTION
## Description

The custom fixture example documents amount-based keys for percentage discount tests:

```json
"expected_discount_reduction": 1.0,
"expected_discount_reduction_2": 1.8
```

`DynamicFixtureContext` does not read either key. `business_logic_test.py` uses `get_expected_discount_percentage()` and `get_expected_discount_percentage_2()`, which look for `expected_discount_percentage` and `expected_discount_percentage_2`; following the README therefore falls back to `0.0` and makes the expected discount amount zero.

The bundled flower-shop fixture already uses the percentage keys with values `10.0` and `20.0`.

**Fix:** align the README example and field descriptions with the percentage keys consumed by the test suite.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [x] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works. (The README fixture is parsed through the production fixture reader.)
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running `generate_models.sh` under `python_sdk`. (Not applicable; no schema or model changes.)

## Screenshots / Logs (if applicable)

```text
README fixture through DynamicFixtureContext: 10.0%, 20.0%
ruff check / ruff format --check: passed
pre-commit: 12 hooks passed
```
