### PR TITLE
fix: validate the published SDK dependency

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Validate published SDK dependency
+        run: uv sync --directory conformance/ --no-sources --no-install-project
+
       - name: Sync dependencies
         run: |
           uv sync --directory python-sdk/

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -38,24 +38,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out conformance repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: conformance
 
       - name: Check out samples repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: Universal-Commerce-Protocol/samples
           path: samples
 
       - name: Check out SDK repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: Universal-Commerce-Protocol/python-sdk
           path: python-sdk
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           prune-cache: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "absl-py>=1.0.0",
     "httpx>=0.26.0",
     "pydantic>=2.12.0",
-    "ucp-sdk==0.3.0",
+    "ucp-sdk==0.4.4",
     "fastapi>=0.109.0",
     "uvicorn[standard]>=0.38.0",
     "ruff>=0.14.11",


### PR DESCRIPTION
## Description

A standalone conformance checkout cannot follow the README's `uv sync` setup: `[tool.uv.sources]` redirects `ucp-sdk` to an absent `../python-sdk/` sibling. Ignoring that local source still installs the stale `ucp-sdk==0.3.0`, whose generated models cannot import the current 2026-04-08 conformance suite.

This updates the published dependency to `ucp-sdk==0.4.4`, the current SDK release for UCP 2026-04-08, while retaining the editable sibling source for coordinated local development. CI now also resolves dependencies with `--no-sources`, so the standalone published-package path cannot silently drift again.

## Testing

- `uv sync --no-sources --no-install-project` in an isolated archive
- imported all 17 `*_test.py` modules against `ucp-sdk==0.4.4`
- full reference-server suite: 15 modules passed; the two webhook modules remain blocked by the known FastAPI response-model issue fixed in open PR #88
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uvx pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally, except for the documented pre-existing webhook blocker in #88
