### PR TITLE
docs: fix custom server test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,13 @@ uv sync
 Run the tests pointing to your server:
 
 ```bash
-SERVER_URL=https://your-merchant-server.com \
-SIMULATION_SECRET=your-sim-secret \
-uv run pytest \
-  --conformance_input=path/to/your/conformance_input.json \
-  --fixture_config=path/to/your/test_fixtures.json
+for test_file in *_test.py; do
+  uv run "${test_file}" \
+    --server_url=https://your-merchant-server.com \
+    --simulation_secret=your-sim-secret \
+    --conformance_input=path/to/your/conformance_input.json \
+    --fixture_config=path/to/your/test_fixtures.json || exit 1
+done
 ```
 
 Alternatively, you can run individual test files and pass arguments:


### PR DESCRIPTION
# Description

The README's "Testing a Custom Server" example currently invokes `uv run pytest` with `--conformance_input` and `--fixture_config`. Those are `absl.flags` flags used by the individual conformance test files, not pytest options, so the documented command fails before the tests are collected.

This updates the custom-server example to use the same per-file runner pattern already used by the repository's conformance CI, passing the custom server URL, simulation secret, conformance input, and fixture config to each `*_test.py` file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected, **including removal of schema files or fields**)
- [x] Documentation update

---

### Is this a Breaking Change or Removal?

N/A. This is a documentation-only update and does not remove schema files or fields.

## Breaking Changes / Removal Justification

N/A.

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Validation:

- `bash -n /tmp/conformance-readme-runner.sh`
- `git diff --check`
- `uvx pre-commit run --all-files`
