### PR TITLE
chore: remove stale conformance runner comment

### DIFF
--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -742,14 +742,7 @@ class IntegrationTestBase(absltest.TestCase):
 
     # Load CSV Test Data
     try:
-      # Resolve relative to this file if not absolute
-      data_dir = FLAGS.test_data_dir
-      if not Path(data_dir).is_absolute():
-        # Assumption: run from where this file is reachable via relative path
-        # Actually, FLAGS.test_data_dir is passed by run_conformance.sh
-        # Let's try to resolve it.
-        pass
-      test_data.load(data_dir)
+      test_data.load(FLAGS.test_data_dir)
     except Exception as e:  # pylint: disable=broad-exception-caught
       logging.warning("Failed to load test CSV data: %s", e)
 


### PR DESCRIPTION
# Description

`integration_test_utils.py` still contained a relative-path branch that claimed
`FLAGS.test_data_dir` was passed by `run_conformance.sh`:

```python
if not Path(data_dir).is_absolute():
  # Actually, FLAGS.test_data_dir is passed by run_conformance.sh
  # Let's try to resolve it.
  pass
```

The repository has no `run_conformance.sh`, and the branch never resolved or
changed the path—the `pass` was followed by `test_data.load(data_dir)` with the
original value.

**Fix:** remove the obsolete no-op branch and pass `FLAGS.test_data_dir` directly
to the existing loader. Runtime behavior is unchanged.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [x] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — `ruff check`, `ruff format --check`, Python compilation, all repository pre-commit hooks, and `git diff --check` pass locally.
