### PR TITLE
chore: update published SDK dependency

### DIFF
--- a/checkout_lifecycle_test.py
+++ b/checkout_lifecycle_test.py
@@ -30,10 +30,10 @@ from ucp_sdk.models.schemas.shopping.types import (
 )
 from ucp_sdk.models.schemas.shopping.types import (
   fulfillment_method_update_request,
+  item_update_request,
+  line_item_update_request,
+  shipping_destination_update_request,
 )
-from ucp_sdk.models.schemas.shopping.types import item_update_request
-from ucp_sdk.models.schemas.shopping.types import line_item_update_request
-from ucp_sdk.models.schemas.shopping.types import shipping_destination
 
 # Rebuild models to resolve forward references
 checkout.Checkout.model_rebuild(_types_namespace={"Payment": Payment})
@@ -126,13 +126,15 @@ class CheckoutLifecycleTest(integration_test_utils.IntegrationTestBase):
       phone_number="+15555555556",
     )
 
-    new_destination = shipping_destination.ShippingDestination(
-      id="dest_2",
-      address_country="US",
-      postal_code="90210",
-      locality="Beverly Hills",
-      region="CA",
-      street_address="456 Elm St",
+    new_destination = (
+      shipping_destination_update_request.ShippingDestinationUpdateRequest(
+        id="dest_2",
+        address_country="US",
+        postal_code="90210",
+        locality="Beverly Hills",
+        region="CA",
+        street_address="456 Elm St",
+      )
     )
 
     existing_method = checkout_obj.fulfillment["methods"][0]

--- a/integration_test_utils.py
+++ b/integration_test_utils.py
@@ -48,7 +48,9 @@ from ucp_sdk.models.schemas.shopping.types import item_update_request
 from ucp_sdk.models.schemas.shopping.types import line_item_create_request
 from ucp_sdk.models.schemas.shopping.types import line_item_update_request
 from ucp_sdk.models.schemas import payment_handler
-from ucp_sdk.models.schemas.shopping.types import shipping_destination
+from ucp_sdk.models.schemas.shopping.types import (
+  shipping_destination_create_request,
+)
 import uvicorn
 
 
@@ -889,15 +891,19 @@ class IntegrationTestBase(absltest.TestCase):
     if include_fulfillment:
       # Hierarchical Fulfillment Construction using dynamic destination
       dest_data = ctx.get_test_destination()
-      destination = shipping_destination.ShippingDestination(
-        id="dest_1",
-        address_country=dest_data.get(
-          "address_country", dest_data.get("country", "US")
-        ),
-        postal_code=dest_data.get("postal_code", "94105"),
-        locality=dest_data.get("locality", dest_data.get("city")),
-        region=dest_data.get("region", dest_data.get("state")),
-        street_address=dest_data.get("street_address", dest_data.get("street")),
+      destination = (
+        shipping_destination_create_request.ShippingDestinationCreateRequest(
+          id="dest_1",
+          address_country=dest_data.get(
+            "address_country", dest_data.get("country", "US")
+          ),
+          postal_code=dest_data.get("postal_code", "94105"),
+          locality=dest_data.get("locality", dest_data.get("city")),
+          region=dest_data.get("region", dest_data.get("state")),
+          street_address=dest_data.get(
+            "street_address", dest_data.get("street")
+          ),
+        )
       )
       group = fulfillment_group_create_request.FulfillmentGroupCreateRequest(
         id="group_1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "absl-py>=1.0.0",
     "httpx>=0.26.0",
     "pydantic>=2.12.0",
-    "ucp-sdk==0.4.4",
+    "ucp-sdk==0.4.5",
     "fastapi>=0.109.0",
     "uvicorn[standard]>=0.38.0",
     "ruff>=0.14.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "absl-py>=1.0.0",
     "httpx>=0.26.0",
     "pydantic>=2.12.0",
-    "ucp-sdk==0.4.5",
+    "ucp-sdk==0.4.6",
     "fastapi>=0.109.0",
     "uvicorn[standard]>=0.38.0",
     "ruff>=0.14.11",


### PR DESCRIPTION
## Description

The standalone conformance installation still pins `ucp-sdk==0.4.4`, while the current published SDK for the same UCP `2026-04-08` release line is `0.4.5`:

```toml
"ucp-sdk==0.4.4",
```

CI explicitly runs `uv sync --no-sources --no-install-project` to validate the published-package path before switching to the editable sibling checkout. Keeping the old pin means that check no longer covers the current published SDK revision.

**Fix:** update the exact published SDK dependency to `0.4.5`. The standalone sync succeeds and all 17 conformance test modules import against that package.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [x] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [ ] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [ ] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `uv sync --no-sources --no-install-project` (resolved `ucp-sdk==0.4.5`)
- imported all 17 `*_test.py` modules with `--no-sources`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uvx pre-commit run --all-files`
- `git diff --check`
