### PR TITLE
fix: restore strict discovery URL validation with fixture allowlist

### DIFF
--- a/protocol_test.py
+++ b/protocol_test.py
@@ -96,9 +96,21 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
 
     return sorted(urls, key=lambda x: x[0])
 
-  import unittest
+  def _is_allowed_unreachable_url(self, url: str) -> bool:
+    """Whether a discovery URL is declared not-yet-published by its owner.
 
-  @unittest.skip("Schemas not yet published on remote ucp.dev domain")
+    Some payment-handler (Google Pay / Shop Pay), mock-handler and REST schema
+    URLs in the merchant's discovery profile are owned by external parties and
+    not yet published for the declared UCP version. They remain real pointer
+    entries in the profile, but their absence must not fail a conformance run.
+    Unreachable URLs are configured per fixture via ``allow_unreachable_urls``
+    in ``conformance_input.json`` (matched as substrings) and should be deleted
+    as each owning party publishes its URL. Every other URL is strictly
+    validated.
+    """
+    allow = (self.conformance_config or {}).get("allow_unreachable_urls", [])
+    return any(pattern in url for pattern in allow)
+
   def test_discovery_urls(self):
     """Verify all spec and schema URLs in discovery profile are valid.
 
@@ -123,6 +135,11 @@ class ProtocolTest(integration_test_utils.IntegrationTestBase):
           # Handle relative URLs if any (AnyUrl should be absolute though)
           res = client.get(url)
           if res.status_code != 200:
+            if self._is_allowed_unreachable_url(url):
+              # Real profile pointer whose owning party has not published it
+              # yet (see _is_allowed_unreachable_url); keep the suite green
+              # while the dependency ships without weakening other checks.
+              continue
             failures.append(f"[{path}] {url} returned status {res.status_code}")
             continue
 

--- a/test_data/flower_shop/conformance_input.json
+++ b/test_data/flower_shop/conformance_input.json
@@ -8,6 +8,12 @@
     "dev.ucp.shopping.buyer_consent"
   ],
   "currency": "USD",
+  "allow_unreachable_urls": [
+    "pay.google.com/gp/p/ucp/2026-04-08",
+    "shopify.dev/ucp/shop-pay-handler/2026-04-08",
+    "ucp.dev/2026-04-08/schemas/mock_payment_handler/spec",
+    "ucp.dev/2026-04-08/services/shopping/openapi.json"
+  ],
   "items": [
     {
       "id": "bouquet_roses",


### PR DESCRIPTION
## Change

`test_discovery_urls` in `protocol_test.py` has been permanently skipped
(`@unittest.skip("Schemas not yet published...")`) — the core UCP
schema/spec URLs for the declared `2026-04-08` version are now public and
the test itself runs cleanly once the blanket skip is removed. This PR
restores that conformance signal:

- removes the blanket skip and the now-unused `import unittest`
- validation is strict again for every URL **not** explicitly allow-listed
- a fixture-level `allow_unreachable_urls` list in
  `test_data/flower_shop/conformance_input.json` declares the seven
  external-party URLs the merchant discovery profile references but whose
  owners (Google Pay / Shop Pay / mock payment handler / REST OpenAPI)
  have not yet published for this version, so the suite stays green
  without weakening any other check
- each entry is a substring match; delete entries as each owning party
  publishes its URL (then that URL is strictly validated again)

## Validation

- 2 files, +25/-2 (`protocol_test.py`,
  `test_data/flower_shop/conformance_input.json`)
- deterministic regression against the latest `samples` discovery profile:
  12 reachable URLs, none allow-listed; all 7 current 404s covered by the
  fixture list; an empty list restores failure on all 7 (non-listed URLs
  stay strict); simulated full run has 0 failures
- `ruff check` / `ruff format` clean, full `pre-commit run --all-files`
  green, `git diff --check` clean

- [x] All validation and checks pass
