### PR TITLE
ci: pin the SDK checkout to the declared ucp-sdk version

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: Universal-Commerce-Protocol/python-sdk
+          ref: v2026-04-08-6
           path: python-sdk
 
       - name: Install uv


### PR DESCRIPTION
Fixes #99.

pyproject.toml declares ucp-sdk==0.4.4 and [tool.uv.sources] redirects it to
../python-sdk/, which the workflow checks out with no ref. CI therefore runs
against python-sdk main rather than the declared version, and a new SDK release
changes this suite with no change here.

This pins the checkout to v2026-04-08-4, the tag that carries ucp-sdk 0.4.4, so
the workflow matches what the repository declares today. The tags map cleanly:
v2026-04-08-4 carries 0.4.4, v2026-04-08-5 carries 0.4.5 and v2026-04-08-6
carries 0.4.6, so the ref can follow the declared version whichever way you take
it.

Measured 2026-09-03 by replicating the workflow locally against conformance
fdbdafd: unpinned, the conformance environment resolves ucp-sdk 0.5.0; with this
ref, it resolves 0.4.4.

#96 proposes moving the declared version to 0.4.5. If that lands first, this ref
should become v2026-04-08-5 in the same change, and I am happy to rebase onto it
rather than have the two cross. I have pinned to the version declared today
rather than choosing a direction for you.

This does not by itself turn the scheduled run green. Two further causes are
tracked in samples: the reference server cannot start under 0.5.0, and the
checkout fixture builds a ShippingDestination where the request union expects
ShippingDestinationCreateRequest.
